### PR TITLE
fix(examples): Remove __rf property from targetNode

### DIFF
--- a/src/components/CodeViewer/example-flows/FloatingEdges/FloatingConnectionLine.js
+++ b/src/components/CodeViewer/example-flows/FloatingEdges/FloatingConnectionLine.js
@@ -10,7 +10,7 @@ function FloatingConnectionLine({ targetX, targetY, sourcePosition, targetPositi
 
   const targetNode = {
     id: 'connection-target',
-    __rf: { width: 1, height: 1, position: { x: targetX, y: targetY } },
+    width: 1, height: 1, position: { x: targetX, y: targetY },
   };
 
   const { sx, sy } = getEdgeParams(sourceNode, targetNode);


### PR DESCRIPTION
Custom connectionline utils crash the app as they try to access `node.position`, `node.width` and `node.height`  but the targetNode has them wrapped in a `__rf` property, which has been removed afaik.