### PR TITLE
Fixed typo in migrate-to-v10.md

### DIFF
--- a/docs/guides/migrate-to-v10.md
+++ b/docs/guides/migrate-to-v10.md
@@ -260,7 +260,7 @@ This is more consistent with the rest of the API (`panOnScroll`, `zoomOnScroll`,
 />
 ```
 
-#### Old API
+#### New API
 
 ```jsx
 <ReactFlow


### PR DESCRIPTION
Fixed typo in the migrate-to-v10.md file where it says "Old API" twice in the same example.