### PR TITLE
Update minimap prop types docs

### DIFF
--- a/docs/api/plugin-components/minimap.md
+++ b/docs/api/plugin-components/minimap.md
@@ -34,14 +34,15 @@ function FlowWithMiniMap() {
 
 ### Prop Types
 
-| Name               | Type                   | Default                   | Description                                                                                                                      |
-| ------------------ | ---------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `nodeColor`        | `string` or `function` | `#fff`                    | If you pass a color string, all nodes get that color. If you pass a function you can return a color depending on the passed node |
-| `nodeBorderRadius` | `number`               | `5`                       | Node border radius                                                                                                               |
-| `nodeStrokeWidth`  | `number`               | `2`                       | Node stroke width                                                                                                                |
-| `nodeClassName`    | `string` or `function` | `''`                      | Node class name                                                                                                                  |
-| `maskColor`        | `string` or `function` | `rgb(240, 242, 243, 0.7)` | Mini map mask color                                                                                                              |
-| `style`            | `CSSProperties`        | `undefined`               | Mini map style attributes                                                                                                        |
-| `className`        | `string`               | `undefined`               | Additional class name                                                                                                            |
+| Name               | Type                   | Default                   | Description                                                                                                                            |
+| ------------------ | ---------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `nodeColor`        | `string` or `function` | `#fff`                    | If you pass a color string, all nodes get that color. If you pass a function you can return a color depending on the passed node       |
+| `nodeStrokeColor`  | `string` or `function` | `#555`                    | If you pass a color string, all nodes get that strokecolor. If you pass a function you can return a color depending on the passed node |
+| `nodeBorderRadius` | `number`               | `5`                       | Node border radius                                                                                                                     |
+| `nodeStrokeWidth`  | `number`               | `2`                       | Node stroke width                                                                                                                      |
+| `nodeClassName`    | `string` or `function` | `''`                      | Node class name                                                                                                                        |
+| `maskColor`        | `string` or `function` | `rgb(240, 242, 243, 0.7)` | Mini map mask color                                                                                                                    |
+| `style`            | `CSSProperties`        | `undefined`               | Mini map style attributes                                                                                                              |
+| `className`        | `string`               | `undefined`               | Additional class name                                                                                                                  |
 
 **Typescript:** The interface of the MiniMap Prop Types are exported as `MiniMapProps`.

--- a/docs/api/plugin-components/minimap.md
+++ b/docs/api/plugin-components/minimap.md
@@ -34,14 +34,14 @@ function FlowWithMiniMap() {
 
 ### Prop Types
 
-| Name               | Type                   | Default     | Description                                                                                                                      |
-| ------------------ | ---------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `nodeColor`        | `string` or `function` | `undefined` | If you pass a color string, all nodes get that color. If you pass a function you can return a color depending on the passed node |
-| `nodeBorderRadius` | `number`               | `0`         | Node border radius                                                                                                               |
-| `nodeStrokeWidth`  | `number`               | `1`         | Node stroke width                                                                                                                |
-| `nodeClassName`    | `function`             | `undefined` | Node class name                                                                                                                  |
-| `maskColor`        | `function`             | `undefined` | Mini map mask color                                                                                                              |
-| `style`            | `CSSProperties`        | `undefined` | Mini map style attributes                                                                                                        |
-| `className`        | `string`               | `undefined` | Additional class name                                                                                                            |
+| Name               | Type                   | Default                   | Description                                                                                                                      |
+| ------------------ | ---------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `nodeColor`        | `string` or `function` | `#fff`                    | If you pass a color string, all nodes get that color. If you pass a function you can return a color depending on the passed node |
+| `nodeBorderRadius` | `number`               | `5`                       | Node border radius                                                                                                               |
+| `nodeStrokeWidth`  | `number`               | `2`                       | Node stroke width                                                                                                                |
+| `nodeClassName`    | `string` or `function` | `''`                      | Node class name                                                                                                                  |
+| `maskColor`        | `string` or `function` | `rgb(240, 242, 243, 0.7)` | Mini map mask color                                                                                                              |
+| `style`            | `CSSProperties`        | `undefined`               | Mini map style attributes                                                                                                        |
+| `className`        | `string`               | `undefined`               | Additional class name                                                                                                            |
 
 **Typescript:** The interface of the MiniMap Prop Types are exported as `MiniMapProps`.


### PR DESCRIPTION
- add the default values from [the code](https://github.com/wbkd/react-flow/blob/main/src/additional-components/MiniMap/index.tsx#L25-L34)
- add docs for [the nodeStrokeColor prop](https://github.com/wbkd/react-flow/blob/main/src/additional-components/MiniMap/index.tsx#L28)


AFTER:
![Screen Shot 2022-04-25 at 3 58 03 PM](https://user-images.githubusercontent.com/5257160/165187987-03a0cea2-06f6-4c68-b861-f99e768a7236.png)
