### PR TITLE
Update custom-nodes.md to link to useUpdateNodeInternals()

### DIFF
--- a/docs/guides/custom-nodes.md
+++ b/docs/guides/custom-nodes.md
@@ -74,4 +74,4 @@ In this case the source node is `node-1` for both handles but the handle ids are
 
 <CodeViewer codePath="api-flows/CustomNode2" applyStyles={false} options={editorOptions} additionalFiles={['TextUpdaterNode.js', 'text-updater-node.css']} />
 
-From here you should be able to build your custom nodes. In most cases we recommend to use custom nodes only. The built-in ones are just basic examples. You can find a list of the passed props and more information in the [custom node API section](/docs/api/nodes/custom-nodes).
+Note that if you are programmatically changing the position or number of handles in your custom node, you will need to use the [`useUpdateNodeInternals`](/docs/api/hooks/use-update-node-internals/) hook to properly notify ReactFlow of changes. From here you should be able to build your custom nodes. In most cases we recommend to use custom nodes only. The built-in ones are just basic examples. You can find a list of the passed props and more information in the [custom node API section](/docs/api/nodes/custom-nodes).


### PR DESCRIPTION
Adding a reference to `useUpdateNodeInternals()` in the Custom Node example so that it's more discoverable

I implemented a custom node with programatically generated handles and spent a while debugging because I did not know about the hook. I was primarily referencing the [Custom Node documentation](https://reactflow.dev/docs/api/nodes/custom-nodes/#prop-types) and [Custom Node guide](https://reactflow.dev/docs/guides/custom-nodes/), but the hook was only mentioned on the [Handles](https://reactflow.dev/docs/api/nodes/handle/#dynamic-handles) docs. It makes sense to reference it in the "Multiple Handles" section for discoverability!
