### PR TITLE
Update in src/components/CodeViewer/example-flows/AddNodeOnEdgeDrop/index.js

### DIFF
--- a/src/components/CodeViewer/example-flows/AddNodeOnEdgeDrop/index.js
+++ b/src/components/CodeViewer/example-flows/AddNodeOnEdgeDrop/index.js
@@ -54,7 +54,7 @@ const AddNodeOnEdgeDrop = () => {
 
         setNodes((nds) => nds.concat(newNode));
         setEdges((eds) =>
-          eds.concat({ id: getId(), source: connectingNodeId.current, target: id })
+          eds.concat({ id, source: connectingNodeId.current, target: id })
         );
       }
     },


### PR DESCRIPTION
`getId()` is calling increment function, so calling it in edge is increasing id by 2, we can just use the stored id.