### PR TITLE
fix(edge-examples): body in foreignObject

### DIFF
--- a/src/components/CodeViewer/example-flows/EdgeWithButton/ButtonEdge.js
+++ b/src/components/CodeViewer/example-flows/EdgeWithButton/ButtonEdge.js
@@ -47,11 +47,11 @@ export default function CustomEdge({
         className="edgebutton-foreignobject"
         requiredExtensions="http://www.w3.org/1999/xhtml"
       >
-        <body>
+        <div>
           <button className="edgebutton" onClick={(event) => onEdgeClick(event, id)}>
             ×
           </button>
-        </body>
+        </div>
       </foreignObject>
     </>
   );

--- a/src/components/CodeViewer/example-flows/EdgeWithButton/index.css
+++ b/src/components/CodeViewer/example-flows/EdgeWithButton/index.css
@@ -13,7 +13,7 @@
   box-shadow: 0 0 6px 2px rgba(0, 0, 0, 0.08);
 }
 
-.edgebutton-foreignobject body {
+.edgebutton-foreignobject div {
   background: transparent;
   width: 40px;
   height: 40px;


### PR DESCRIPTION
# Problem

In ["Examples > Edges > Edges with Button"](https://reactflow.dev/docs/examples/edges/edge-with-button/), the example code puts `<body>` as the child of `<foreignObject>`:

```js
export default function CustomEdge({/* ... */}) {
  /* ... */
  return (
    <>
      <path {/* ... */} />
      <foreignObject {/* ... */}>
        <body>
          {/* ... */}
        </body>
      </foreignObject>
    </>
  );
}
```

However, I got the following warning when I open the example in Code Sandbox:

![image](https://user-images.githubusercontent.com/57580593/198928849-ac47f46f-0943-4aa1-b5f1-7b795ccf4d81.png)

# Solution

This PR fixes the above problem by changing `<body>` to a `<div>`.