### PR TITLE
Updated 'toY' to 'fromY'

### DIFF
--- a/docs-data/custom-connection-line/index.tsx
+++ b/docs-data/custom-connection-line/index.tsx
@@ -5,7 +5,7 @@ const props = [
     description: 'x position of the source handle',
   },
   {
-    name: 'toY',
+    name: 'fromY',
     type: 'number',
     description: 'y position of the source handle',
   },


### PR DESCRIPTION
- `toY` was not appropriate as per the `description` attribute
-  The appropriate `toY` is repeated in line 23