### PR TITLE
missed onEdgeDoubleClick prop in Props List

### DIFF
--- a/docs-data/react-flow-props/edges.tsx
+++ b/docs-data/react-flow-props/edges.tsx
@@ -14,6 +14,17 @@ const props = [
     description: 'Called when user clicks an edge',
   },
   {
+    name: 'onEdgeDoubleClick',
+    type: (
+      <>
+        (event: React.MouseEvent, edge:{' '}
+        <Link to="/docs/api/edges/edge-options/#typescript">Edge</Link>) =&gt; void
+      </>
+    ),
+    default: 'undefined',
+    description: 'Called when user clicks double an edge',
+  },
+  {
     name: 'onEdgeMouseEnter',
     type: (
       <>


### PR DESCRIPTION
see: [onEdgeDoubleClick](https://github.com/wbkd/react-flow/blob/4963aec71a9b6160afbb60e8bc1457d1b1657a0e/packages/core/src/types/edges.ts#L71)

![image](https://user-images.githubusercontent.com/3505959/218374086-aa1e4c3c-58bc-4170-af08-22a67ee9678c.png)