### PR TITLE
📝 Improve emoji accessibility.

### DIFF
--- a/blog/2022-09-28-react-flow-v11-release.md
+++ b/blog/2022-09-28-react-flow-v11-release.md
@@ -25,7 +25,7 @@ A lot has happened since we published our last blog post six months ago. We got 
 - Better selectable edges with a new `interactionWidth` option
 - New hooks: `useNodesInitialized`, `useOnViewportChange` and `useOnSelectionChange`
 
-## 🎉 A New Package Name
+## <Emoji content="🎉" /> A New Package Name
 
 The biggest change, is that we got a new package name! A very nice person gave us the [`reactflow` npm package](https://www.npmjs.com/reactflow) name and we also got the [`@reactflow` organization](https://www.npmjs.com/org/reactflow). So from now on, you can install React Flow via:
 
@@ -49,7 +49,7 @@ import 'reactflow/dist/style.css';
 
 Looks nice, right? Under the hood we are publishing packages separately in the `@reactflow` organization. These packages are used by the main `reactflow` package and also can be [used separately](/docs/overview/packages/). For this we've rebuilt React Flow to a monorepo powered by [turborepo](https://turborepo.org/), [Rollup](https://rollupjs.org/) and [Vite](https://vitejs.dev/).
 
-## ✨ New Features
+## <Emoji content="✨" /> New Features
 
 For this release, we focused on accessibility (nothing better for a v11 release than a11y!) and edges, with some other smaller updates and stability fixes along the way.
 

--- a/blog/2022-09-28-react-flow-v11-release.md
+++ b/blog/2022-09-28-react-flow-v11-release.md
@@ -9,8 +9,9 @@ blogSidebarCount: 0
 ---
 
 import Image from '@theme/IdealImage';
+import Emoji from '/src/components/Emoji';
 
-A lot has happened since we published our last blog post six months ago. We got our first pro subscribers, we hired John who helps us with the docs, communication and community and we are all working full time on React Flow 🥳. Today we are releasing a new major version with lots of new features and very few breaking changes (unlike the last major update..).
+A lot has happened since we published our last blog post six months ago. We got our first pro subscribers, we hired John who helps us with the docs, communication and community and we are all working full time on React Flow <Emoji content="🥳" />. Today we are releasing a new major version with lots of new features and very few breaking changes (unlike the last major update..).
 
 <!--truncate-->
 
@@ -76,7 +77,7 @@ Furthermore we've implemented a [`useNodesInitialized` hook](/docs/api/hooks/use
 
 ### New Hooks
 
-In the future we want to get rid of some `<ReactFlow />` component props (there are 140+ 😵‍💫). One idea is to replace some props through hooks. With this release we are adding the [`useOnViewportChange`](/docs/api/hooks/use-on-viewport-change) and the [`useOnSelectionChange`](/docs/api/hooks/use-on-selection-change) hook. Before this release you could only listen to a viewport change by using `onMoveStart`, `onMove` and `onMoveEnd`. With the new `useOnViewportChange` hook, you can easily listen to changes in every component.
+In the future we want to get rid of some `<ReactFlow />` component props (there are 140+ <Emoji content="😵‍💫" />). One idea is to replace some props through hooks. With this release we are adding the [`useOnViewportChange`](/docs/api/hooks/use-on-viewport-change) and the [`useOnSelectionChange`](/docs/api/hooks/use-on-selection-change) hook. Before this release you could only listen to a viewport change by using `onMoveStart`, `onMove` and `onMoveEnd`. With the new `useOnViewportChange` hook, you can easily listen to changes in every component.
 
 ### Miscellaneous
 
@@ -86,4 +87,4 @@ The background got a [new variant `cross`](/docs/api/plugin-components/backgroun
 
 React Flow is not just the library. It's the website with the docs and the examples, the pro platform and also the community on Github and Discord! In the upcoming weeks and months we want to make the onboarding for developers and especially beginner developers easier. For that we are working on an in-depth getting started guide and easier to understand docs in general. We are also rebrushing the pro platform so that you can get more out of the pro examples.
 
-Thanks for being a part of the React Flow community, and happy coding! ✌🏻
+Thanks for being a part of the React Flow community, and happy coding! <Emoji content="✌🏻" />

--- a/blog/2022-11-01-react-flow-fall-update.mdx
+++ b/blog/2022-11-01-react-flow-fall-update.mdx
@@ -10,6 +10,7 @@ image: /img/blog/v10-header.png
 import NewsletterSignup from '../src/components/NewsletterSignup/inline';
 
 import Image from '@theme/IdealImage';
+import Emoji from '/src/components/Emoji';
 
 Howdy! Here’s a dispatch straight from our desks about what’s happened in the last couple of months at React Flow: updates, news, and a peek behind-the-scenes. Here we go.
 
@@ -17,9 +18,9 @@ Howdy! Here’s a dispatch straight from our desks about what’s happened in th
 
 ## Launching v11 and post-release housekeeping
 
-React Flow v11 went live in early October (woohoo! 🎉), and Moritz wrote a [whole blog post](https://reactflow.dev/blog/react-flow-v11/) all about it if you haven't seen yet.
+React Flow v11 went live in early October (woohoo! <Emoji content="🎉" />), and Moritz wrote a [whole blog post](https://reactflow.dev/blog/react-flow-v11/) all about it if you haven't seen yet.
 
-Post-launch, we took a few weeks to tend to our current structures. We made some fixes to accessibility updates from v11 (thanks to some wonderful user feedback 💕), added the new props `nodesFocusable` and `edgesFocusable` to make the keyboard handling better configurable , and took some time to refocus ourselves for the end of the year. (Shout-out to Supabase for the inspiration on [post-release weeks](https://github.com/supabase/supabase/releases/tag/0.22.09).)
+Post-launch, we took a few weeks to tend to our current structures. We made some fixes to accessibility updates from v11 (thanks to some wonderful user feedback <Emoji content="💕" />), added the new props `nodesFocusable` and `edgesFocusable` to make the keyboard handling better configurable , and took some time to refocus ourselves for the end of the year. (Shout-out to Supabase for the inspiration on [post-release weeks](https://github.com/supabase/supabase/releases/tag/0.22.09).)
 
 Slowly but surely, folks are starting to use our new package name. `react-flow-renderer` is dead, long live `reactflow`! (data from [npmtrends](https://npmtrends.com/react-flow-renderer-vs-reactflow))
 

--- a/blog/2022-11-16-npm-package.mdx
+++ b/blog/2022-11-16-npm-package.mdx
@@ -16,7 +16,7 @@ In 2019 we started building [a library for building node based UIs](https://gith
 
 Three years and many Github stars later, we wanted a sleeker name. Both “reactflow” and “react-flow” hadn’t been used or changed for over 6 years, so I found the email address associated with “reactflow” using `npm view reactflow _npmUser`, sent a nice email asking if we could use it, and crossed fingers.
 
-Within just 2 hours, the owner replied, and said he had already handed over the rights to us (?!?!). Faster and easier than expected thanks to a quick-responding stranger, we were in business 🔥 We were about to publish a new major version, and were excited that a fresh new “reactflow” package would come with the release.
+Within just 2 hours, the owner replied, and said he had already handed over the rights to us (?!?!). Faster and easier than expected thanks to a quick-responding stranger, we were in business <Emoji content="🔥" />. We were about to publish a new major version, and were excited that a fresh new “reactflow” package would come with the release.
 
 <Image img="/img/blog/npm/package-handover.png" alt="email from reactflow package handover" />
 
@@ -54,9 +54,9 @@ With a frantic google search, it turns out npm introduced a [typosquat security 
 
 Two minutes of wallowing and frantic google searching later, I realised that I really messed up and wrote npm a message explaining my situation. They answered that there is nothing they can do about it and that we should use a scoped package name instead or follow the package name dispute policy [https://www.npmjs.com/policies/disputes](https://www.npmjs.com/policies/disputes). This was bad.
 
-We wrote some mails back and forth, and finally at the end of the day, they rolled back the mistake I made and restored the previous version 0.1.0 What a relief! 🙏
+We wrote some mails back and forth, and finally at the end of the day, they rolled back the mistake I made and restored the previous version 0.1.0 What a relief! <Emoji content="🙏" />
 
-Thanks to npm support, everyone who wants to use React Flow can use `npm install reactflow` instead of `npm install react-flow-renderer`, which was released along with our [v11 update](https://reactflow.dev/blog/react-flow-v11/). Feels good. 😌
+Thanks to npm support, everyone who wants to use React Flow can use `npm install reactflow` instead of `npm install react-flow-renderer`, which was released along with our [v11 update](https://reactflow.dev/blog/react-flow-v11/). Feels good. <Emoji content="😌" />
 
 ## How to not make the same mistake
 

--- a/blog/2022-12-19-react-flow-v11-4.mdx
+++ b/blog/2022-12-19-react-flow-v11-4.mdx
@@ -8,6 +8,7 @@ image: /img/blog/v10-header.png
 ---
 
 import Image from '@theme/IdealImage';
+import Emoji from '/src/components/Emoji';
 
 Hey! We wanted to share an update about what we’ve been up to before we wrap ourselves up in blankets to hibernate until the new year (we’ll be shutting our laptops from today until January 2nd ⛄). Let’s get into what’s been up the past few months, what’s coming, and what we’re excited about right now.
 
@@ -50,7 +51,7 @@ We hope to continue on this path, this will mean talking to some of you all (yay
 
 **We shared our mistakes** of [how we lost our slick new npm package name (and then got it back)](https://reactflow.dev/blog/reactflow-npm-package-name/).
 
-**A lot of people liked our list of [Awesome Node Based UIs](https://github.com/wbkd/awesome-node-based-uis)** with resources, libraries, and good-looking apps. Within a month of publishing it we already have more than 120 entries, 22 contributors and 1k Github stars!! So cool. And this [comment](https://news.ycombinator.com/item?id=33641786) on Hackernews was too good not to share 😊
+**A lot of people liked our list of [Awesome Node Based UIs](https://github.com/wbkd/awesome-node-based-uis)** with resources, libraries, and good-looking apps. Within a month of publishing it we already have more than 120 entries, 22 contributors and 1k Github stars!! So cool. And this [comment](https://news.ycombinator.com/item?id=33641786) on Hackernews was too good not to share <Emoji content="😊" />.
 
 <Image img="/img/blog/winter-2022/hackernews.png" alt="a screenshot from a comment on hackernews" />
 

--- a/blog/2023-01-10-mind-map-app-with-react-flow.mdx
+++ b/blog/2023-01-10-mind-map-app-with-react-flow.mdx
@@ -8,6 +8,7 @@ image: /img/blog/mindmap/mindmap.png
 ---
 
 import Image from '@theme/IdealImage';
+import Emoji from '/src/components/Emoji';
 import { AspectRatio } from '@chakra-ui/react';
 import CodeViewer from '/src/components/CodeViewer';
 const editorOptions = { editorHeight: '45vh' };
@@ -16,7 +17,7 @@ In this tutorial, you will learn to create a simple mind map tool with React Flo
 
 <!--truncate-->
 
-## 🎬 It's Demo Time!
+## <Emoji content="🎬" /> It's Demo Time!
 
 Before we get our hands dirty, I want to show you the mindmapping tool we'll have by the end of this tutorial:
 
@@ -31,9 +32,9 @@ Before we get our hands dirty, I want to show you the mindmapping tool we'll hav
 
 If you'd like to live dangerously and dive right into the code, you can find the source code on [Github](https://github.com/wbkd/react-flow-mindmap-app).
 
-## 👩🏻‍💻 Getting started
+## <Emoji content="👩🏻‍💻" /> Getting started
 
-To do this tutorial you will need some knowledge of [React](https://reactjs.org/docs/getting-started.html) and [React Flow](/docs/overview/terms-and-definitions/) (hi, that's us! 😁 it's an open source library for building node-based UIs like workflow tools, ETL pipelines, and [more](https://reactflow.dev/showcase/).)
+To do this tutorial you will need some knowledge of [React](https://reactjs.org/docs/getting-started.html) and [React Flow](/docs/overview/terms-and-definitions/) (hi, that's us! <Emoji content="😁" /> it's an open source library for building node-based UIs like workflow tools, ETL pipelines, and [more](https://reactflow.dev/showcase/).)
 
 We'll be using [Vite](https://vitejs.dev/) to develop our app, but you can also use [Create React App](https://create-react-app.dev/) or any other tool you like. To scaffold a new React app with Vite you need to do:
 
@@ -127,7 +128,7 @@ We are adding all styles of our app to the `index.css` file (you could also use 
   isTypescript
 />
 
-## 🏪 A store for nodes and edges
+## <Emoji content="🏪" /> A store for nodes and edges
 
 As mentioned above, we are using Zustand for state management. For this, we create a new file in our `src/App` folder called `store.ts`:
 
@@ -178,7 +179,7 @@ const useStore = create<RFState>((set, get) => ({
 export default useStore;
 ```
 
-It seems like a lot of code, but it's mostly types 😇 The store keeps track of the nodes and edges and handles the change events. When a user drags a node, React Flow fires a change event, the store then applies the changes and the updated nodes get rendered. (You can read more about this in our [state management library guide](/docs/api/hooks/use-store/).)
+It seems like a lot of code, but it's mostly types <Emoji content="😇" /> The store keeps track of the nodes and edges and handles the change events. When a user drags a node, React Flow fires a change event, the store then applies the changes and the updated nodes get rendered. (You can read more about this in our [state management library guide](/docs/api/hooks/use-store/).)
 
 As you can see we start with one initial node placed at `{ x: 0, y: 0 }` of type 'mindmap'. To connect the store with our app, we use the `useStore` hook:
 
@@ -235,9 +236,9 @@ We access the nodes, edges and change handlers from the store and pass them to t
   isTypescript
 />
 
-You can move the node around and zoom in and out, we are getting somewhere 🚀 Now let's add some more functionality.
+You can move the node around and zoom in and out, we are getting somewhere <Emoji content="🚀" /> Now let's add some more functionality.
 
-## ✨ Custom nodes and edges
+## <Emoji content="✨" /> Custom nodes and edges
 
 We want to use a custom type called 'mindmap' for our nodes. We need to add a new component for this. Let's create a new folder called `MindMapNode` with an index file under `src/App` with the following content:
 
@@ -332,7 +333,7 @@ and then pass the newly created types to the React Flow component.
 
 Nice! We can already change the labels of our nodes by clicking in the input field and typing something.
 
-## 🆕 New nodes
+## <Emoji content="🆕" /> New nodes
 
 We want to make it super quick for a user to create a new node. The user should be able to add a new node by clicking on a node and drag to the position where a new node should be placed. This functionality is not built into React Flow, but we can implement it by using the [`onConnectStart` and `onConnectEnd`](/docs/api/react-flow-props/#onconnectstart) handlers.
 
@@ -456,7 +457,7 @@ This function returns the position of the new node we want to add to our store. 
 
 To test the new functionality you can start a connection from a handle and then end it on the pane. You should see a new node being added to the mind map.
 
-## 🤝 Keep data in sync
+## <Emoji content="🤝" /> Keep data in sync
 
 We can already update the labels but we are not updating the nodes data object. This is important to keep our app in sync and if we want to save our nodes on the server for example. To achieve this we add a new action called `updateNodeLabel` to the store. This action takes a node id and a label. The implementation is pretty straight forward: we iterate over the existing nodes and update the matching one with the passed label:
 
@@ -514,7 +515,7 @@ export default MindMapNode;
 
 That was quick! The input fields of the custom nodes now display the current label of the nodes. You could take your nodes data, save it on the server and then load it again.
 
-## 💅 Simpler UX and nicer styling
+## <Emoji content="💅" /> Simpler UX and nicer styling
 
 Functionality-wise we are finished with our mind map app! We can add new nodes, update their labels and move them around. But the UX and styling could use some improvements. Let's make it easier to drag the nodes and to create new nodes!
 
@@ -808,7 +809,7 @@ body {
 }
 ```
 
-Nicely done! 💯 You can find the final code here:
+Nicely done! <Emoji content="💯" /> You can find the final code here:
 
 <CodeViewer
   codePath="blog-flows/mindmap/NodeAsHandle4"
@@ -819,7 +820,7 @@ Nicely done! 💯 You can find the final code here:
   isTypescript
 />
 
-## 👋 Final thoughts
+## <Emoji content="👋" /> Final thoughts
 
 What a trip! We started with an empty pane and ended with a fully functional mind map app. If you want to move on you could work on some of the following features:
 

--- a/blog/2023-01-26-react-flow-v11-5.mdx
+++ b/blog/2023-01-26-react-flow-v11-5.mdx
@@ -8,6 +8,7 @@ image: /img/blog/v10-header.png
 ---
 
 import Image from '@theme/IdealImage';
+import Emoji from '/src/components/Emoji';
 
 Hello again! I am super excited to share the latest improvements of React Flow. The new auto pan features and connection radius makes it way easier to connect nodes and work with bigger flows. On top of that we improved the usability on touch devices.
 
@@ -21,7 +22,7 @@ After working a bit with Blender geometry nodes I knew that I wanted to add this
 
 ## Connection radius
 
-There are [several](/docs/examples/nodes/easy-connect/) [ways](/docs/examples/nodes/proximity-connect/) to connect nodes. The built-in way is to drag a connection line from one handle to another. To make this easier we added the [`connectionRadius` prop](/docs/api/react-flow-props/#connectionradius-1). The connection radius specifies the radius around a handle where you can drop the connection line. There is no need to drop it directly above a handle any more 🙌.
+There are [several](/docs/examples/nodes/easy-connect/) [ways](/docs/examples/nodes/proximity-connect/) to connect nodes. The built-in way is to drag a connection line from one handle to another. To make this easier we added the [`connectionRadius` prop](/docs/api/react-flow-props/#connectionradius-1). The connection radius specifies the radius around a handle where you can drop the connection line. There is no need to drop it directly above a handle any more <Emoji content="🙌" />.
 
 <Image img="/img/blog/v11-5/connection-radius.gif" alt="Conneciton radius demo." />
 
@@ -43,7 +44,7 @@ type MyCustomNode = Node<MyCustomNodeData, 'custom-node-type'>;
 
 This allows you to create more specific node types that are aware of their `data` structure and `type`.
 
-# 👉 Node Resizer 2.0 👈
+# <Emoji content="👉" /> Node Resizer 2.0 <Emoji content="👈" />
 
 We also released a new major version of the [`@reactflow/node-resizer` package](/docs/api/nodes/node-resizer/). You can now pass a `shouldResize` handler that allows you to cancel a resize event. In addition we added a `direction` attribute to the resize params for `onResize` and `shouldResize`.
 

--- a/src/components/Emoji/index.tsx
+++ b/src/components/Emoji/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export type EmojiProps = {
+  content: string;
+  label?: string;
+};
+
+// Using emojis in prose is often inaccessible: screen readers typically do a
+// pretty rubbish job reading them out and they totally break the flow of the
+// text for anyone using one.
+//
+// This component is a simple span wrapper that _either_ renders the emoji with
+// an aria-label (and the appropriate role) if a label is provided, or removes it
+// from the accessibility tree entirely if not.
+//
+export default function Emoji({ content, label }: EmojiProps) {
+  if (label) {
+    return (
+      <span role="img" aria-label={label}>
+        {content}
+      </span>
+    );
+  } else {
+    return <span aria-hidden="true">{content}</span>;
+  }
+}

--- a/src/components/Emoji/index.tsx
+++ b/src/components/Emoji/index.tsx
@@ -14,13 +14,11 @@ export type EmojiProps = {
 // from the accessibility tree entirely if not.
 //
 export default function Emoji({ content, label }: EmojiProps) {
-  if (label) {
-    return (
-      <span role="img" aria-label={label}>
-        {content}
-      </span>
-    );
-  } else {
-    return <span aria-hidden="true">{content}</span>;
-  }
+  return label ? (
+    <span role="img" aria-label={label}>
+      {content}
+    </span>
+  ) : (
+    <span aria-hidden="true">{content}</span>
+  );
 }


### PR DESCRIPTION
This adds a new `Emoji` component we should try to use in blog posts going forward. Screen readers are pretty hit-or-miss with emojis: some read them, some ignore them, and some spit out unicode garbage.

This component just wraps the given content in a `<span aria-hidden="true">` to remove it from the accessibility tree entirely. Optionally, you can supply a label in which case the span is given `role="img"` and an accompanying `aria-label` instead.

I've gone through the past blog posts and wrapped all the emojis I could find. This does have the (unfortunate?) side effect of removing the emojis from the headings in the sidebar:

<img width="140" alt="image" src="https://user-images.githubusercontent.com/9001354/220957765-8e382c17-669c-4fb9-8e22-ecea86e987e8.png">

I don't think it's the end of the world but maybe y'all disagree 😅 