### PR TITLE
fix: small typo in spelling

### DIFF
--- a/docs/api/nodes/node-resizer.md
+++ b/docs/api/nodes/node-resizer.md
@@ -12,7 +12,7 @@ import CodeViewer from '../../../src/components/CodeViewer';
 The node resizer component can be used to add a resize functionality to your nodes. It renders draggable controls around the node to resize in all directions.
 
 :::info
-The `NodeResizer` component is **not** part of the `reactflow` package. You need to install it seperately and you need reactflow >= v11.3.3 for this to work.
+The `NodeResizer` component is **not** part of the `reactflow` package. You need to install it separately and you need reactflow >= v11.3.3 for this to work.
 :::
 
 ### Installation


### PR DESCRIPTION
There was a small typo in the spelling of `separately`