### PR TITLE
✨ Update `<MiniMap/>` documentation to include `nodeComponent` prop and types.

### DIFF
--- a/docs-data/minimap/custom-node.tsx
+++ b/docs-data/minimap/custom-node.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+
+const props = [
+  {
+    name: 'id',
+    description: 'The id of the React Flow node.',
+    type: 'string',
+  },
+  {
+    name: 'x',
+    description: 'The x position of the React Flow node.',
+    type: 'number',
+  },
+  {
+    name: 'y',
+    description: 'The y position of the React Flow node.',
+    type: 'number',
+  },
+  {
+    name: 'width',
+    description: 'The width of the React Flow node.',
+    type: 'number',
+  },
+  {
+    name: 'height',
+    description: 'The height of the React Flow node.',
+    type: 'number',
+  },
+  {
+    name: 'borderRadius',
+    description: (
+      <>
+        The border radius passed into the <code>nodeBorderRadius</code> prop of the{' '}
+        <code>MiniMap</code> component.
+      </>
+    ),
+    type: 'number',
+  },
+  {
+    name: 'className',
+    description: (
+      <>
+        The class name passed into the <code>nodeClassName</code> prop of the <code>MiniMap</code>{' '}
+        component.
+      </>
+    ),
+    type: 'string',
+  },
+  {
+    name: 'color',
+    description: (
+      <>
+        The color passed into the <code>nodeColor</code> prop of the <code>{'<MiniMap />'}</code>
+        component, or the color computed by the function passed in instead.
+      </>
+    ),
+    type: 'string',
+  },
+  {
+    name: 'shapeRendering',
+    description:
+      'This is computed based on your browser and some other factors and can be used to hint at the SVG renderer on how to optimize the rendering of paths.',
+    type: '"crispEdges" | "geometricPrecision"',
+  },
+  {
+    name: 'strokeColor',
+    description: (
+      <>
+        The stroke color passed into the <code>nodeStrokeColor</code> prop of the{' '}
+        <code>MiniMap</code> component.
+      </>
+    ),
+    type: 'string',
+  },
+  {
+    name: 'strokeWidth',
+    description: (
+      <>
+        The stroke width passed into the <code>nodeStrokeWidth</code> prop of the{' '}
+        <code>MiniMap</code>
+        component.',
+      </>
+    ),
+    type: 'number',
+  },
+  {
+    name: 'style?',
+    description: 'Any styles set on the React Flow node.',
+    type: 'CSSProperties',
+  },
+  {
+    name: 'onClick?',
+    description: 'An optional click handler for the minimap node.',
+    type: '(event: MouseEvent, id: string) => void',
+  },
+];
+
+export default props;

--- a/docs-data/minimap/index.tsx
+++ b/docs-data/minimap/index.tsx
@@ -48,10 +48,15 @@ const props = [
     default: "''",
     description: 'Node class name',
   },
-   {
+  {
     name: 'nodeComponent',
-    type: 'React Node',
-    default: "undefined",
+    type: (
+      <>
+        React.ComponentType(
+        {<Link to="#custom-node-prop-types">MiniMapNodeProps</Link>})
+      </>
+    ),
+    default: 'undefined',
     description: 'Custom component for a node.',
   },
   {

--- a/docs/api/plugin-components/minimap.md
+++ b/docs/api/plugin-components/minimap.md
@@ -23,9 +23,31 @@ import options from '../../../docs-data/minimap';
 
 <PropItems props={options} />
 
+## Custom MiniMap Nodes
+
+You can swap out the default component used for nodes in the minimap with whatever
+you want by setting the `nodeComponent` prop on the `<MiniMap />` component. Below
+is the same example as before, but now we're rendering a circle
+instead of a rectangle!
+
+<CodeViewer options={{ editorHeight: 500, editorWidthPercentage: 45, wrapContent: true }} codePath="api-flows/MiniMapCustomNode" applyStyles={false} additionalFiles={['nodes.js', 'edges.js', 'MiniMapNode.js']} />
+
+:::info You must use SVG
+
+For performance reasons, the minimap is rendered as an SVG. This means that you
+**must** use SVG elements for your custom node component if you want it to work
+properly.
+:::
+
+### Custom Node Prop Types
+
+import customNodeOptions from '../../../docs-data/minimap/custom-node';
+
+<PropItems props={customNodeOptions} />
+
 ### Typescript
 
-The interface of the MiniMap Prop Types are exported as `MiniMapProps`.
+The interface of both the `<MiniMap />` and custom node props are exported as `MiniMapProps` and `MiniMapNodeProps` respectively.
 
 ### Npm Package
 

--- a/src/components/CodeViewer/api-flows/MiniMapCustomNode/MiniMapNode.js
+++ b/src/components/CodeViewer/api-flows/MiniMapCustomNode/MiniMapNode.js
@@ -1,0 +1,3 @@
+export default function MiniMapNode({ x, y, color }) {
+  return <circle cx={x} cy={y} r="50" fill={color} />;
+}

--- a/src/components/CodeViewer/api-flows/MiniMapCustomNode/edges.js
+++ b/src/components/CodeViewer/api-flows/MiniMapCustomNode/edges.js
@@ -1,0 +1,4 @@
+export default initialEdges = [
+  { id: 'e1-2', source: '1', target: '2' },
+  { id: 'e2-3', source: '2', target: '3', animated: true },
+];

--- a/src/components/CodeViewer/api-flows/MiniMapCustomNode/index.js
+++ b/src/components/CodeViewer/api-flows/MiniMapCustomNode/index.js
@@ -1,0 +1,34 @@
+import ReactFlow, { MiniMap } from 'reactflow';
+import 'reactflow/dist/style.css';
+
+import defaultNodes from './nodes.js';
+import defaultEdges from './edges.js';
+
+import MiniMapNode from './MiniMapNode.js';
+
+const nodeColor = (node) => {
+  switch (node.type) {
+    case 'input':
+      return '#6ede87';
+    case 'output':
+      return '#6865A5';
+    default:
+      return '#ff0072';
+  }
+};
+
+function Flow() {
+  return (
+    <ReactFlow defaultNodes={defaultNodes} defaultEdges={defaultEdges} fitView>
+      <MiniMap
+        nodeColor={nodeColor}
+        nodeStrokeWidth={3}
+        nodeComponent={MiniMapNode}
+        zoomable
+        pannable
+      />
+    </ReactFlow>
+  );
+}
+
+export default Flow;

--- a/src/components/CodeViewer/api-flows/MiniMapCustomNode/nodes.js
+++ b/src/components/CodeViewer/api-flows/MiniMapCustomNode/nodes.js
@@ -1,0 +1,24 @@
+export default [
+  {
+    id: '1',
+    type: 'input',
+    data: { label: 'Input Node' },
+    position: { x: 250, y: 25 },
+    style: { backgroundColor: '#6ede87', color: 'white' },
+  },
+
+  {
+    id: '2',
+    // you can also pass a React component as a label
+    data: { label: <div>Default Node</div> },
+    position: { x: 100, y: 125 },
+    style: { backgroundColor: '#ff0072', color: 'white' },
+  },
+  {
+    id: '3',
+    type: 'output',
+    data: { label: 'Output Node' },
+    position: { x: 250, y: 250 },
+    style: { backgroundColor: '#6865A5', color: 'white' },
+  },
+];

--- a/src/components/CodeViewer/index.js
+++ b/src/components/CodeViewer/index.js
@@ -26,7 +26,7 @@ html, body, #root {
 
 const defaultSetup = {
   dependencies: {
-    reactflow: '11.5.6',
+    reactflow: '11.6.1',
   },
 };
 


### PR DESCRIPTION
- Adds the new `nodeComponent` field to the docs for `MiniMap` props.
- Adds a new section "Custom MiniMap Nodes":
  - Adds docs for the `MiniMapNodeProps` type.
  - Adds a new `<CodeViewer />` example demoing custom minimap nodes.
- Updates the `<CodeViewer />` component to use React Flow **11.6.1**.