### PR TITLE
Fix deprecated create in default zustand import

### DIFF
--- a/blog/2023-01-10-mind-map-app-with-react-flow.mdx
+++ b/blog/2023-01-10-mind-map-app-with-react-flow.mdx
@@ -145,7 +145,7 @@ import {
   applyNodeChanges,
   applyEdgeChanges,
 } from 'reactflow';
-import create from 'zustand';
+import { create } from 'zustand';
 
 export type RFState = {
   nodes: Node[];

--- a/src/components/CodeViewer/api-flows/StateManagement/store.ts
+++ b/src/components/CodeViewer/api-flows/StateManagement/store.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import {
   Connection,
   Edge,

--- a/src/components/CodeViewer/api-flows/StateManagement2/store.ts
+++ b/src/components/CodeViewer/api-flows/StateManagement2/store.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import {
   Connection,
   Edge,

--- a/src/components/CodeViewer/blog-flows/mindmap/App/store.ts
+++ b/src/components/CodeViewer/blog-flows/mindmap/App/store.ts
@@ -9,7 +9,7 @@ import {
   applyEdgeChanges,
   XYPosition,
 } from 'reactflow';
-import create from 'zustand';
+import { create } from 'zustand';
 import { nanoid } from 'nanoid/non-secure';
 
 export type RFState = {

--- a/src/components/CodeViewer/blog-flows/mindmap/CreateNodes/store.ts
+++ b/src/components/CodeViewer/blog-flows/mindmap/CreateNodes/store.ts
@@ -9,7 +9,7 @@ import {
   applyEdgeChanges,
   XYPosition,
 } from 'reactflow';
-import create from 'zustand';
+import { create } from 'zustand';
 import { nanoid } from 'nanoid/non-secure';
 
 export type RFState = {

--- a/src/components/CodeViewer/blog-flows/mindmap/CustomNodesEdges/store.ts
+++ b/src/components/CodeViewer/blog-flows/mindmap/CustomNodesEdges/store.ts
@@ -8,7 +8,7 @@ import {
   applyNodeChanges,
   applyEdgeChanges,
 } from 'reactflow';
-import create from 'zustand';
+import { create } from 'zustand';
 
 export type RFState = {
   nodes: Node[];

--- a/src/components/CodeViewer/blog-flows/mindmap/NodeAsHandle/store.ts
+++ b/src/components/CodeViewer/blog-flows/mindmap/NodeAsHandle/store.ts
@@ -9,7 +9,7 @@ import {
   applyEdgeChanges,
   XYPosition,
 } from 'reactflow';
-import create from 'zustand';
+import { create } from 'zustand';
 import { nanoid } from 'nanoid/non-secure';
 
 export type RFState = {

--- a/src/components/CodeViewer/blog-flows/mindmap/NodeAsHandle2/store.ts
+++ b/src/components/CodeViewer/blog-flows/mindmap/NodeAsHandle2/store.ts
@@ -9,7 +9,7 @@ import {
   applyEdgeChanges,
   XYPosition,
 } from 'reactflow';
-import create from 'zustand';
+import { create } from 'zustand';
 import { nanoid } from 'nanoid/non-secure';
 
 export type RFState = {

--- a/src/components/CodeViewer/blog-flows/mindmap/NodeAsHandle3/store.ts
+++ b/src/components/CodeViewer/blog-flows/mindmap/NodeAsHandle3/store.ts
@@ -9,7 +9,7 @@ import {
   applyEdgeChanges,
   XYPosition,
 } from 'reactflow';
-import create from 'zustand';
+import { create } from 'zustand';
 import { nanoid } from 'nanoid/non-secure';
 
 export type RFState = {

--- a/src/components/CodeViewer/blog-flows/mindmap/NodeAsHandle4/store.ts
+++ b/src/components/CodeViewer/blog-flows/mindmap/NodeAsHandle4/store.ts
@@ -9,7 +9,7 @@ import {
   applyEdgeChanges,
   XYPosition,
 } from 'reactflow';
-import create from 'zustand';
+import { create } from 'zustand';
 import { nanoid } from 'nanoid/non-secure';
 
 export type RFState = {

--- a/src/components/CodeViewer/blog-flows/mindmap/StoreNodesEdges/store.ts
+++ b/src/components/CodeViewer/blog-flows/mindmap/StoreNodesEdges/store.ts
@@ -8,7 +8,7 @@ import {
   applyNodeChanges,
   applyEdgeChanges,
 } from 'reactflow';
-import create from 'zustand';
+import { create } from 'zustand';
 
 export type RFState = {
   nodes: Node[];


### PR DESCRIPTION
```import create from 'zustand';``` is deprecated. It seems we need to do import it as a named import now.

Thank you so much to the amazing developers who created this package 🤩🙏👏



