### PR TITLE
Fix: Correct default edge ID typo in edge markers example

### DIFF
--- a/src/components/CodeViewer/example-flows/Markers/index.js
+++ b/src/components/CodeViewer/example-flows/Markers/index.js
@@ -51,7 +51,7 @@ const defaultEdges = [
     label: 'default arrow',
   },
   {
-    id: 'C->B',
+    id: 'C->D',
     source: 'C',
     target: 'D',
     markerEnd: {


### PR DESCRIPTION
This PR fixes a typo in the default edge ID of the edge markers example.

# Changes:
- Corrected the default edge ID from `C->B` to `C->D` to match the source and target nodes.