### PR TITLE
📝 Add an example to recreate edges when a node is deleted.

### DIFF
--- a/docs/examples/nodes/delete-middle-node.mdx
+++ b/docs/examples/nodes/delete-middle-node.mdx
@@ -1,0 +1,96 @@
+---
+title: Delete Middle Node
+hide_table_of_contents: true
+---
+
+import CodeViewer from '/src/components/CodeViewer';
+
+This example shows you how recover deleted edges when you remove a node from the
+middle of a chain. In other words, if we have three nodes connected in sequence -
+`a->b->c` - and we deleted the middle node `b`, this example shows you how to end
+up with the graph `a->c`.
+
+To achieve this, we need to make use of a few bits:
+
+- The [`onNodesDelete`](/docs/api/react-flow-props/#onnodesdelete) callback lets
+  us know when a node is deleted.
+- [`getConnectedEdges`](/docs/api/graph-util-functions/#getconnectededges) gives us
+  all the edges connected to a node, either as source or target.
+- [`getIncomers`](/docs/api/graph-util-functions/#getincomers) and
+  [`getOutgoers`](/docs/api/graph-util-functions/#getoutgoers) give us the nodes
+  connected to a node as source or target.
+
+This comes together to allow us to take all the nodes connected to the deleted
+node, and reconnect them to any nodes the deleted node was connected to.
+
+<CodeViewer codePath="example-flows/DeleteMiddleNode" />
+
+Although this example is less than 20 lines of code there's quite a lot to digest.
+Let's break some of it down:
+
+- Our `onNodesDelete` callback is called with one argument - `deleted` - that is an
+  array of every node that was just deleted. If you select an individual node and
+  press the delete key, `deleted` will contain just that node, but if you make a
+  selection _all_ the nodes in that selection will be in `deleted`.
+
+- We create a new array of edges - `remainingEdges` - that contains all the edges
+  in the flow that have nothing to do with the node(s) we just deleted.
+
+- We create another array of edges by _flatMapping_ over the array of `incomers`.
+  These are nodes that were connected to the deleted node as a source. For each
+  of these nodes, we create a new edge that connects to each node in the array of
+  `outgoers`. These are nodes that were connected to the deleted node as a target.
+
+:::info
+For brevity, we're using object destructuring while at the same time renaming
+the variable bound (e.g. `({ id: source }) => ...)` destructures the `id`
+property of the object and binds it to a new variable called `source`) but you
+don't need to do this
+:::
+
+## Quick Reference
+
+<div className="next-steps">
+  <a className="next-steps__item" href="/docs/api/react-flow-props/#onnodesdelete">
+    <span className="next-steps__item-sublabel">Called when nodes get deleted</span>
+    <span>onNodesDelete</span>
+  </a>
+  <a className="next-steps__item" href="/docs/api/graph-util-functions/#getconnectededges">
+    <span className="next-steps__item-sublabel">
+      Returns all edges that are connected to the passed nodes
+    </span>
+    <span>getConnectedEdges</span>
+  </a>
+  <a className="next-steps__item" href="/docs/api/graph-util-functions/#getincomers">
+    <span className="next-steps__item-sublabel">
+      Returns all direct incoming nodes of the passed node
+    </span>
+    <span>getIncomers</span>
+  </a>
+  <a className="next-steps__item" href="/docs/api/graph-util-functions/#getoutgoers">
+    <span className="next-steps__item-sublabel">
+      Returns all direct child nodes of the passed node
+    </span>
+    <span>getOutgoers</span>
+  </a>
+  <a
+    className="next-steps__item"
+    target="_blank"
+    href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap"
+  >
+    <span className="next-steps__item-sublabel">
+      Map each element in an array and flatten the result
+    </span>
+    <span>Array.prototype.flatMap</span>
+  </a>
+  <a
+    className="next-steps__item"
+    target="_blank"
+    href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#assigning_to_new_variable_names"
+  >
+    <span className="next-steps__item-sublabel">
+      Rename a variable bound in object destructuring
+    </span>
+    <span>Destructuring assignment</span>
+  </a>
+</div>

--- a/src/components/CodeViewer/example-flows/DeleteMiddleNode/index.js
+++ b/src/components/CodeViewer/example-flows/DeleteMiddleNode/index.js
@@ -1,0 +1,69 @@
+import React, { useCallback } from 'react';
+import ReactFlow, {
+  Background,
+  useNodesState,
+  useEdgesState,
+  addEdge,
+  getIncomers,
+  getOutgoers,
+  getConnectedEdges,
+} from 'reactflow';
+
+import 'reactflow/dist/style.css';
+
+const initialNodes = [
+  { id: '1', type: 'input', data: { label: 'Start here...' }, position: { x: -150, y: 0 } },
+  { id: '2', type: 'input', data: { label: '...or here!' }, position: { x: 150, y: 0 } },
+  { id: '3', data: { label: 'Delete me.' }, position: { x: 0, y: 100 } },
+  { id: '4', data: { label: 'Then me!' }, position: { x: 0, y: 200 } },
+  { id: '5', type: 'output', data: { label: 'End here!' }, position: { x: 0, y: 300 } },
+];
+
+const initialEdges = [
+  { id: '1->3', source: '1', target: '3' },
+  { id: '2->3', source: '2', target: '3' },
+  { id: '3->4', source: '3', target: '4' },
+  { id: '4->5', source: '4', target: '5' },
+];
+
+export default function Flow() {
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+  const onConnect = useCallback((params) => setEdges(addEdge(params, edges)), [edges]);
+  const onNodesDelete = useCallback(
+    (deleted) => {
+      setEdges(
+        deleted.reduce((acc, node) => {
+          const incomers = getIncomers(node, nodes, edges);
+          const outgoers = getOutgoers(node, nodes, edges);
+          const connectedEdges = getConnectedEdges([node], edges);
+
+          const remainingEdges = acc.filter((edge) => !connectedEdges.includes(edge));
+
+          const createdEdges = incomers.flatMap(({ id: source }) =>
+            outgoers.map(({ id: target }) => ({ id: `${source}->${target}`, source, target }))
+          );
+
+          return [...remainingEdges, ...createdEdges];
+        }, edges)
+      );
+    },
+    [nodes, edges]
+  );
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onNodesDelete={onNodesDelete}
+      onEdgesChange={onEdgesChange}
+      onConnect={onConnect}
+      fitView
+      attributionPosition="top-right"
+    >
+      <Background variant="dots" gap={12} size={1} />
+    </ReactFlow>
+  );
+}


### PR DESCRIPTION
Closes #99.

Neat little example that shows off how reconnect up nodes when a middle one is deleted, eg deleting `b` in `a->b->c` and then connecting `a->c`.

https://user-images.githubusercontent.com/9001354/228707749-aacd68ea-1d71-4b6f-a021-1c995b225bb9.mov

---

I've also trialed a format to point readers to relevant API docs (including external links) at the end of the example.  

<img width="1115" alt="Screenshot 2023-03-30 at 02 54 28" src="https://user-images.githubusercontent.com/9001354/228707900-71ef3f9f-5f06-44f3-a88e-b46928e7b522.png">
