### PR TITLE
Add searchable description of deleteKeyCode

### DIFF
--- a/docs/api/react-flow-props.md
+++ b/docs/api/react-flow-props.md
@@ -103,7 +103,7 @@ import connectionLine from '../../docs-data/react-flow-props/connection-line';
 
 ## Keys
 
-Use these props to disable the backspace or delete key and more.
+Use these props to disable or change the node and edge delete key (default is backspace) or the keys to draw a selection box:
 
 import keys from '../../docs-data/react-flow-props/keys';
 

--- a/docs/api/react-flow-props.md
+++ b/docs/api/react-flow-props.md
@@ -103,6 +103,8 @@ import connectionLine from '../../docs-data/react-flow-props/connection-line';
 
 ## Keys
 
+Use these props to disable the backspace or delete key and more.
+
 import keys from '../../docs-data/react-flow-props/keys';
 
 <PropItems props={keys} />


### PR DESCRIPTION
We get a question at least once per month in the Discord server asking how to disable the button that deletes nodes. If a user currently searches for "backspace," this page doesn't appear as a result. Adding this short description under the Keys headline should make this section searchable and less people should have to troubleshoot this.