### PR TITLE
feat(examples): add connection limit example

### DIFF
--- a/docs/examples/nodes/connection-limit.mdx
+++ b/docs/examples/nodes/connection-limit.mdx
@@ -1,0 +1,17 @@
+---
+sidebar_label: Connection Limit
+title: Connection Limit
+description: This is an example of a custom node limiting the amount of connections a handle can have using the `isConnectalbe` prop.
+hide_table_of_contents: true
+---
+import CodeViewer from '/src/components/CodeViewer';
+
+This is an example of a custom node with a custom handle that can limit the amount of connections a handle can have using the `isConnectable` prop.
+You can use a boolean, a number (the number of max. connections the handle should have) or a callback function that returns a boolean
+as an arg for the `isConnectable` prop of the CustomHandle component.
+
+<CodeViewer
+  codePath="example-flows/ConnectionLimit"
+  additionalFiles={['CustomNode.js', 'CustomHandle.js']}
+/>
+

--- a/src/components/CodeViewer/example-flows/ConnectionLimit/CustomHandle.js
+++ b/src/components/CodeViewer/example-flows/ConnectionLimit/CustomHandle.js
@@ -1,0 +1,36 @@
+import React, { useMemo } from 'react';
+import { getConnectedEdges, Handle, useNodeId, useStore } from 'reactflow';
+
+const selector = (s) => ({
+    nodeInternals: s.nodeInternals,
+    edges: s.edges,
+});
+
+const CustomHandle = (props) => {
+    const { nodeInternals, edges } = useStore(selector);
+    const nodeId = useNodeId();
+
+    const isHandleConnectable = useMemo(() => {
+        if (typeof props.isConnectable === 'function') {
+            const node = nodeInternals.get(nodeId);
+            const connectedEdges = getConnectedEdges([node], edges);
+
+            return props.isConnectable({ node, connectedEdges });
+        }
+
+        if (typeof props.isConnectable === 'number') {
+            const node = nodeInternals.get(nodeId);
+            const connectedEdges = getConnectedEdges([node], edges);
+
+            return connectedEdges.length < props.isConnectable;
+        }
+
+        return props.isConnectable;
+    }, [nodeInternals, edges, nodeId, props.isConnectable]);
+
+    return (
+        <Handle {...props} isConnectable={isHandleConnectable}></Handle>
+    );
+};
+
+export default CustomHandle;

--- a/src/components/CodeViewer/example-flows/ConnectionLimit/CustomNode.js
+++ b/src/components/CodeViewer/example-flows/ConnectionLimit/CustomNode.js
@@ -1,0 +1,14 @@
+import React, { memo } from 'react';
+import { Position } from 'reactflow';
+import CustomHandle from './CustomHandle';
+
+const CustomNode = () => {
+    return (
+        <div style={{ background: 'white', padding: 16, border: '1px solid black' }}>
+            <CustomHandle type="target" position={Position.Left} isConnectable={1} />
+            <div>Connection Limit 1</div>
+        </div>
+    );
+};
+
+export default memo(CustomNode);

--- a/src/components/CodeViewer/example-flows/ConnectionLimit/index.js
+++ b/src/components/CodeViewer/example-flows/ConnectionLimit/index.js
@@ -1,0 +1,55 @@
+import { useCallback } from 'react';
+import ReactFlow, { addEdge, Position, useNodesState, useEdgesState } from 'reactflow';
+
+import 'reactflow/dist/style.css';
+
+import CustomNode from './CustomNode';
+
+const nodeTypes = {
+    custom: CustomNode,
+};
+
+const CustomNodeFlow = () => {
+    const [nodes, setNodes, onNodesChange] = useNodesState([
+        {
+            id: '1',
+            type: 'input',
+            data: { label: 'Node 1' },
+            position: { x: 0, y: 25 },
+            sourcePosition: Position.Right,
+        },
+        {
+            id: '2',
+            type: 'custom',
+            data: {},
+            position: { x: 250, y: 50 },
+        },
+        {
+            id: '3',
+            type: 'input',
+            data: { label: 'Node 2' },
+            position: { x: 0, y: 100 },
+            sourcePosition: Position.Right,
+        },
+    ]);
+    const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+
+    const onConnect = useCallback(
+        (params) => setEdges((eds) => addEdge(params, eds)),
+        [setEdges]
+    );
+
+    return (
+        <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            nodeTypes={nodeTypes}
+            fitView
+        />
+    );
+};
+
+export default CustomNodeFlow;


### PR DESCRIPTION
# What's changed?

- Add an example to show how to limit connection on a handle (as this keeps getting asked often in Discussions/Discord)