### PR TITLE
Teeny tiny typo in troubleshooting guide

### DIFF
--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -402,7 +402,7 @@ This can happen when you are trying to [update an edge](/docs/examples/edges/upd
 
 ### Couldn't create edge for source/target handle id: "some-id"; edge id: "some-id".
 
-This can happen if you are working with multiple handles and a handle is not found by it's `id` property. Please see the [Custom Node Example](/docs/examples/nodes/custom-node) for an example of working with multiple handles.
+This can happen if you are working with multiple handles and a handle is not found by its `id` property. Please see the [Custom Node Example](/docs/examples/nodes/custom-node) for an example of working with multiple handles.
 
 ### Marker type doesn't exist.
 


### PR DESCRIPTION
I hit this error and went to the docs, and noticed the small typo