### PR TITLE
fix(examples): use correct props for floating connection line

### DIFF
--- a/src/components/CodeViewer/example-flows/FloatingEdges/FloatingConnectionLine.js
+++ b/src/components/CodeViewer/example-flows/FloatingEdges/FloatingConnectionLine.js
@@ -3,8 +3,8 @@ import { getBezierPath } from 'reactflow';
 
 import { getEdgeParams } from './utils.js';
 
-function FloatingConnectionLine({ targetX, targetY, sourcePosition, targetPosition, sourceNode }) {
-  if (!sourceNode) {
+function FloatingConnectionLine({ toX, toY, fromPosition, toPosition, fromNode }) {
+  if (!fromNode) {
     return null;
   }
 
@@ -12,24 +12,37 @@ function FloatingConnectionLine({ targetX, targetY, sourcePosition, targetPositi
     id: 'connection-target',
     width: 1,
     height: 1,
-    position: { x: targetX, y: targetY },
+    positionAbsolute: { x: toX, y: toY }
   };
 
-  const { sx, sy } = getEdgeParams(sourceNode, targetNode);
+  const { sx, sy } = getEdgeParams(fromNode, targetNode);
   const [edgePath] = getBezierPath({
     sourceX: sx,
     sourceY: sy,
-    sourcePosition,
-    targetPosition,
-    targetX,
-    targetY,
+    sourcePosition: fromPosition,
+    targetPosition: toPosition,
+    targetX: toX,
+    targetY: toY
   });
 
   return (
-    <g>
-      <path fill="none" stroke="#222" strokeWidth={1.5} className="animated" d={edgePath} />
-      <circle cx={targetX} cy={targetY} fill="#fff" r={3} stroke="#222" strokeWidth={1.5} />
-    </g>
+      <g>
+        <path
+            fill="none"
+            stroke="#222"
+            strokeWidth={1.5}
+            className="animated"
+            d={edgePath}
+        />
+        <circle
+            cx={toX}
+            cy={toY}
+            fill="#fff"
+            r={3}
+            stroke="#222"
+            strokeWidth={1.5}
+        />
+      </g>
   );
 }
 


### PR DESCRIPTION
# What's changed?

- Connection line props were renamed but example uses the old prop names