### PR TITLE
♻️ Simplify connection limit example.

### DIFF
--- a/docs/examples/nodes/connection-limit.mdx
+++ b/docs/examples/nodes/connection-limit.mdx
@@ -1,17 +1,27 @@
 ---
 sidebar_label: Connection Limit
 title: Connection Limit
-description: This is an example of a custom node limiting the amount of connections a handle can have using the `isConnectalbe` prop.
 hide_table_of_contents: true
 ---
+
 import CodeViewer from '/src/components/CodeViewer';
 
-This is an example of a custom node with a custom handle that can limit the amount of connections a handle can have using the `isConnectable` prop.
-You can use a boolean, a number (the number of max. connections the handle should have) or a callback function that returns a boolean
-as an arg for the `isConnectable` prop of the CustomHandle component.
+This example shows how to implement a custom handle that can limit the number of
+connections it can have. It works in tandem with the existing [`isConnectable`](https://reactflow.dev/docs/api/nodes/handle/#isconnectable)
+prop so you can always completely disable a handle if you need to. All you need
+to do is provide a `maxConnections` prop to the handle. If you leave it out, it'll
+assume there's no limit.
+
+To see it in action, try and connect `Node 1` to the middle target node or `Node 2`
+to the first target node. You'll see that it doesn't work! Try connecting both
+nodes to the bottom target node that has no connection limit, and everything will
+behave as normal.
 
 <CodeViewer
   codePath="example-flows/ConnectionLimit"
-  additionalFiles={['CustomNode.js', 'CustomHandle.js']}
+  additionalFiles={['CustomNode.js', 'CustomHandle.js', 'nodes-edges.js']}
 />
 
+If you're feeling fancy you could extend this example to let `maxConnections`
+be a function can calculates that maximum dynamically, but we'll leave that down
+to you!

--- a/src/components/CodeViewer/example-flows/ConnectionLimit/CustomHandle.js
+++ b/src/components/CodeViewer/example-flows/ConnectionLimit/CustomHandle.js
@@ -1,28 +1,33 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { getConnectedEdges, Handle, useNodeId, useStore } from 'reactflow';
 
-const selector = (s) => ({
-  nodeInternals: s.nodeInternals,
-  edges: s.edges,
-});
+const selector =
+  (nodeId, isConnectable = true, maxConnections = Infinity) =>
+  (s) => {
+    // If the user props say this handle is not connectable, we don't need to
+    // bother checking anything else.
+    if (!isConnectable) return false;
+
+    const node = s.nodeInternals.get(nodeId);
+    const connectedEdges = getConnectedEdges([node], s.edges);
+
+    return connectedEdges.length < maxConnections;
+  };
 
 const CustomHandle = (props) => {
-  const { nodeInternals, edges } = useStore(selector);
   const nodeId = useNodeId();
+  const isConnectable = useStore(
+    useCallback(selector(nodeId, props.isConnectable, props.maxConnections), [
+      nodeId,
+      props.isConnectable,
+      props.maxConnections,
+    ])
+  );
 
-  const isConnectable = useMemo(() => {
-    const node = nodeInternals.get(nodeId);
-    const connectedEdges = getConnectedEdges([node], edges);
-    const maxConnections = props.maxConnections ?? Infinity;
-
-    // The `isConnectable` prop can be passed to any Handle to enable/disable
-    // it: it's part of React Flow!
-    //
-    // https://reactflow.dev/docs/api/nodes/handle/#isconnectable
-    return props.isConnectable && connectedEdges.length < maxConnections;
-  }, [nodeInternals, edges, nodeId, props.isConnectable, props.maxConnections]);
-
-  return <Handle {...props} type="target" isConnectable={isConnectable}></Handle>;
+  // The `isConnectable` prop is a part of React Flow, all we need to do is give
+  // it the bool we calculated above and React Flow can handle the logic to disable
+  // it for us.
+  return <Handle {...props} type="target" isConnectable={isConnectable} />;
 };
 
 export default CustomHandle;

--- a/src/components/CodeViewer/example-flows/ConnectionLimit/CustomHandle.js
+++ b/src/components/CodeViewer/example-flows/ConnectionLimit/CustomHandle.js
@@ -2,35 +2,27 @@ import React, { useMemo } from 'react';
 import { getConnectedEdges, Handle, useNodeId, useStore } from 'reactflow';
 
 const selector = (s) => ({
-    nodeInternals: s.nodeInternals,
-    edges: s.edges,
+  nodeInternals: s.nodeInternals,
+  edges: s.edges,
 });
 
 const CustomHandle = (props) => {
-    const { nodeInternals, edges } = useStore(selector);
-    const nodeId = useNodeId();
+  const { nodeInternals, edges } = useStore(selector);
+  const nodeId = useNodeId();
 
-    const isHandleConnectable = useMemo(() => {
-        if (typeof props.isConnectable === 'function') {
-            const node = nodeInternals.get(nodeId);
-            const connectedEdges = getConnectedEdges([node], edges);
+  const isConnectable = useMemo(() => {
+    const node = nodeInternals.get(nodeId);
+    const connectedEdges = getConnectedEdges([node], edges);
+    const maxConnections = props.maxConnections ?? Infinity;
 
-            return props.isConnectable({ node, connectedEdges });
-        }
+    // The `isConnectable` prop can be passed to any Handle to enable/disable
+    // it: it's part of React Flow!
+    //
+    // https://reactflow.dev/docs/api/nodes/handle/#isconnectable
+    return props.isConnectable && connectedEdges.length < maxConnections;
+  }, [nodeInternals, edges, nodeId, props.isConnectable, props.maxConnections]);
 
-        if (typeof props.isConnectable === 'number') {
-            const node = nodeInternals.get(nodeId);
-            const connectedEdges = getConnectedEdges([node], edges);
-
-            return connectedEdges.length < props.isConnectable;
-        }
-
-        return props.isConnectable;
-    }, [nodeInternals, edges, nodeId, props.isConnectable]);
-
-    return (
-        <Handle {...props} isConnectable={isHandleConnectable}></Handle>
-    );
+  return <Handle {...props} type="target" isConnectable={isConnectable}></Handle>;
 };
 
 export default CustomHandle;

--- a/src/components/CodeViewer/example-flows/ConnectionLimit/CustomNode.js
+++ b/src/components/CodeViewer/example-flows/ConnectionLimit/CustomNode.js
@@ -2,13 +2,26 @@ import React, { memo } from 'react';
 import { Position } from 'reactflow';
 import CustomHandle from './CustomHandle';
 
-const CustomNode = () => {
-    return (
-        <div style={{ background: 'white', padding: 16, border: '1px solid black' }}>
-            <CustomHandle type="target" position={Position.Left} isConnectable={1} />
-            <div>Connection Limit 1</div>
-        </div>
-    );
+const CustomNode = ({ data }) => {
+  const { isConnectable, maxConnections } = data;
+  const styles = {
+    background: 'white',
+    padding: 16,
+    border: '1px solid black',
+    opacity: isConnectable ? '100%' : '50%',
+  };
+
+  return (
+    <div style={styles}>
+      <CustomHandle
+        position={Position.Left}
+        isConnectable={isConnectable}
+        maxConnections={maxConnections}
+      />
+      <div>Is Connectable: {`${isConnectable}`}</div>
+      <div>Connection Limit: {maxConnections ?? 'infinite'}</div>
+    </div>
+  );
 };
 
 export default memo(CustomNode);

--- a/src/components/CodeViewer/example-flows/ConnectionLimit/index.js
+++ b/src/components/CodeViewer/example-flows/ConnectionLimit/index.js
@@ -1,55 +1,32 @@
 import { useCallback } from 'react';
 import ReactFlow, { addEdge, Position, useNodesState, useEdgesState } from 'reactflow';
+import { initialNodes, initialEdges } from './nodes-edges';
 
 import 'reactflow/dist/style.css';
 
 import CustomNode from './CustomNode';
 
 const nodeTypes = {
-    custom: CustomNode,
+  custom: CustomNode,
 };
 
 const CustomNodeFlow = () => {
-    const [nodes, setNodes, onNodesChange] = useNodesState([
-        {
-            id: '1',
-            type: 'input',
-            data: { label: 'Node 1' },
-            position: { x: 0, y: 25 },
-            sourcePosition: Position.Right,
-        },
-        {
-            id: '2',
-            type: 'custom',
-            data: {},
-            position: { x: 250, y: 50 },
-        },
-        {
-            id: '3',
-            type: 'input',
-            data: { label: 'Node 2' },
-            position: { x: 0, y: 100 },
-            sourcePosition: Position.Right,
-        },
-    ]);
-    const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
 
-    const onConnect = useCallback(
-        (params) => setEdges((eds) => addEdge(params, eds)),
-        [setEdges]
-    );
+  const onConnect = useCallback((params) => setEdges((eds) => addEdge(params, eds)), [setEdges]);
 
-    return (
-        <ReactFlow
-            nodes={nodes}
-            edges={edges}
-            onNodesChange={onNodesChange}
-            onEdgesChange={onEdgesChange}
-            onConnect={onConnect}
-            nodeTypes={nodeTypes}
-            fitView
-        />
-    );
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      onConnect={onConnect}
+      nodeTypes={nodeTypes}
+      fitView
+    />
+  );
 };
 
 export default CustomNodeFlow;

--- a/src/components/CodeViewer/example-flows/ConnectionLimit/nodes-edges.js
+++ b/src/components/CodeViewer/example-flows/ConnectionLimit/nodes-edges.js
@@ -1,0 +1,51 @@
+export const initialNodes = [
+  {
+    id: 'a',
+    type: 'input',
+    sourcePosition: 'right',
+    data: { label: 'Node 1' },
+    position: {
+      x: 0,
+      y: 50,
+    },
+  },
+  {
+    id: 'b',
+    type: 'input',
+    sourcePosition: 'right',
+    data: { label: 'Node 2' },
+    position: {
+      x: 0,
+      y: 150,
+    },
+  },
+  {
+    id: 'c',
+    type: 'custom',
+    data: { isConnectable: true, maxConnections: 1 },
+    position: {
+      x: 250,
+      y: 0,
+    },
+  },
+  {
+    id: 'd',
+    type: 'custom',
+    data: { isConnectable: false, maxConnections: 1 },
+    position: {
+      x: 250,
+      y: 100,
+    },
+  },
+  {
+    id: 'e',
+    type: 'custom',
+    data: { isConnectable: true },
+    position: {
+      x: 250,
+      y: 200,
+    },
+  },
+];
+
+export const initialEdges = [{ id: 'a->c', source: 'a', target: 'c' }];


### PR DESCRIPTION
This makes the connection limit example by @bcakmakoglu a bit more easily digestible.

- Use separate `maxConnections` prop instead of re-purposing the built-in `isConnectable` one.
- Remove code showing how to pass in a function to `maxConnections`.
- Expand example flow with additional nodes to better demonstrate how things work.