### PR TITLE
fix(docs): fix useOnViewportChange ts reference

### DIFF
--- a/docs/api/hooks/use-on-viewport-change.md
+++ b/docs/api/hooks/use-on-viewport-change.md
@@ -31,7 +31,7 @@ function ViewportChangeLogger() {
 ### Typescript
 
 ```js
-useViewport({
+useOnViewportChange({
   onStart?: (viewport: Viewport) => void,
   onChange?: (viewport: Viewport) => void,
   onEnd?: (viewport: Viewport) => void


### PR DESCRIPTION
The docs for `useOnviewportChange` were incorrectly referencing `useViewport` in the typescript section