### PR TITLE
fix: middle point miscalculation when zoom changes

### DIFF
--- a/src/components/CodeViewer/example-flows/AddNodeOnEdgeDrop/index.js
+++ b/src/components/CodeViewer/example-flows/AddNodeOnEdgeDrop/index.js
@@ -31,7 +31,7 @@ const AddNodeOnEdgeDrop = () => {
   const connectingNodeId = useRef(null);
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
-  const { project } = useReactFlow();
+  const { project, getZoom } = useReactFlow();
   const onConnect = useCallback((params) => setEdges((eds) => addEdge(params, eds)), []);
 
   const onConnectStart = useCallback((_, { nodeId }) => {
@@ -49,7 +49,7 @@ const AddNodeOnEdgeDrop = () => {
         const newNode = {
           id,
           // we are removing the half of the node width (75) to center the new node
-          position: project({ x: event.clientX - left - 75, y: event.clientY - top }),
+          position: project({ x: event.clientX - left - 75 * getZoom(), y: event.clientY - top }),
           data: { label: `Node ${id}` },
         };
 


### PR DESCRIPTION
After altering the zoom, width of the node should be also updated according to the current zoom value.

This is required because the width (and height) of the node will be changed after zoom-out, ie. it will be 50px wide instead of 150px on the screen, to be correctly projected.

**Maybe a comment or info bubble can also be added to document.**

Original:
[![Edit damp-microservice-95s3g4](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/damp-microservice-95s3g4?fontsize=14&hidenavigation=1&module=%2FApp.js&theme=dark)

Pull request:
[![Edit dazzling-mayer-m59sjw](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/dazzling-mayer-m59sjw?fontsize=14&hidenavigation=1&module=%2FApp.js&theme=dark&view=preview)