### PR TITLE
📝 Create a layouting guide to enumerate some of the options

### DIFF
--- a/docs/guides/layouting.mdx
+++ b/docs/guides/layouting.mdx
@@ -1,0 +1,252 @@
+---
+title: Layouting
+sidebar_position: 5
+---
+
+import CodeViewer from '/src/components/CodeViewer';
+const editorOptions = { editorHeight: 500 };
+
+We regularly get asked how to handle layouting in React Flow. While we could build
+some basic layouting into React Flow, we believe that **you know your app's
+requirements best** and with so many options out there we think it's better you
+choose the best right tool for the job (not to mention it'd be a whole bunch of
+work for us).
+
+That doesn't help very much if you don't know what the options _are_, so this
+guide is here to help! We'll split things up into resources for layouting nodes
+and resources for routing edges.
+
+To start let's put together a simple example flow that we can use as a base for
+testing out the different layouting options.
+
+<CodeViewer
+  codePath="api-flows/LayoutingFlow1-Empty"
+  editorOptions={editorOptions}
+  applyStyles={false}
+  additionalFiles={['nodes-edges.js']}
+/>
+
+## Layouting Nodes
+
+For layouting nodes we have a few options, you may want to consider:
+
+<div className="next-steps" style={{ margin: '0 0 var(--ifm-paragraph-margin-bottom)' }}>
+  <a className="next-steps__item" href="https://github.com/dagrejs/dagre">
+    <span className="next-steps__item-sublabel">Directed graph layout for JavaScript</span>
+    <span>
+      dagre <sup>⬈</sup>
+    </span>
+  </a>
+  <a className="next-steps__item" href="https://github.com/d3/d3-hierarchy">
+    <span className="next-steps__item-sublabel">
+      2D layout algorithms for visualizing hierarchical data.
+    </span>
+    <span>
+      d3-hierarchy <sup>⬈</sup>
+    </span>
+  </a>
+  <a className="next-steps__item" href="https://github.com/kieler/elkjs">
+    <span className="next-steps__item-sublabel">ELK's layout algorithms for JavaScript</span>
+    <span>
+      elkjs <sup>⬈</sup>
+    </span>
+  </a>
+  <a className="next-steps__item" href="#honourable-mentions">
+    <span className="next-steps__item-sublabel">
+      Alternatives we haven't had time to explore yet
+    </span>
+    <span>Honourable mentions</span>
+  </a>
+</div>
+
+We've loosely ordered these options from simplest to most complex, where dagre
+is largely a drop-in solution and elkjs is a full-blown highly configurable
+layouting engine.
+
+Let's take a look at a brief example of how each of these libraries can be used
+with React Flow. For dagre and elkjs specifically, we have some separate examples
+you can refer back to [here](https://reactflow.dev/docs/examples/layout/dagre/)
+and [here](https://reactflow.dev/docs/examples/layout/elkjs/).
+
+### Dagre
+
+Dagre is a simple library for layouting directed graphs. It has minimal configuration
+options and a focus on speed over choosing the most optimal layout. If you need
+to organise your flows into a tree, _we highly recommend dagre_.
+
+<CodeViewer
+  codePath="api-flows/LayoutingFlow2-Dagre"
+  editorOptions={editorOptions}
+  applyStyles={false}
+  additionalFiles={['nodes-edges.js']}
+  dependencies={{ '@dagrejs/dagre': 'latest' }}
+/>
+
+With no effort at all we get a well-organised tree layout! Whenever
+`getLayoutedElements` is called, we'll reset the dagre graph and set the graph's
+direction (either left-to-right or top-to-bottom) based on the `direction` prop.
+Dagre needs to know the dimensions of each node in order to lay them out, so we
+iterate over our list of nodes and add them to dagre's internal graph.
+
+After laying out the graph, we'll return an object with the layouted nodes and
+edges. We do this by mapping over the original list of nodes and updating each
+node's position according to node stored in the dagre graph.
+
+Documentation for dagre's configuration options can be found
+[here](https://github.com/dagrejs/dagre/wiki#configuring-the-layout), including
+properties to set for spacing and alignment.
+
+:::info
+In this example we use `Element.getBoundingClientRect` to get the dimensions of
+each node. You should think twice about doing this in your own apps if you allow
+zooming: the dimensions of the nodes will change as the user zooms in and out!
+
+Dagre also expects every node in the graph to have the same dimensions. If you
+have lots of different-sized nodes you may want to consider one of the other
+options below, or configuring dagre with the largest dimensions you expect to
+see.
+:::
+
+### D3-Hierarchy
+
+When you know your graph is a tree with a single root node, d3-hierarchy can
+provide a handful of interesting layouting options. While the library can layout
+a simple tree just fine, it also has layouting algorithms for tree maps, partition
+layouts, and enclosure diagrams.
+
+<CodeViewer
+  codePath="api-flows/LayoutingFlow3-D3-Hierarchy"
+  editorOptions={editorOptions}
+  applyStyles={false}
+  additionalFiles={['nodes-edges.js']}
+  dependencies={{ 'd3-hierarchy': 'latest' }}
+/>
+
+:::info
+D3-hierarchy expects your graphs to have a single root node, so it won't work
+in all cases. It's also important to note that d3-hierarchy assigns the same
+width and height to _all_ nodes when calculating the layout, so it's not the best
+choice if you're displaying lots of different node types.
+:::
+
+### D3-Force
+
+Force something more interesting than a tree, a force-directed layout might be
+the way to go. D3-Force is a physics-based layouting library that can be used
+position nodes by applying different forces to them.
+
+As a consequence, it's a little more complicated to configure and use compared to
+dagre and d3-hierarchy. Importantly, d3-force's layouting algorithm is iterative,
+so we need a way to keep computing the layout across multiple renders.
+
+First, let's see what it does:
+
+<CodeViewer
+  codePath="api-flows/LayoutingFlow4-D3-Force"
+  editorOptions={editorOptions}
+  applyStyles={false}
+  additionalFiles={['nodes-edges.js', 'collide.js']}
+  dependencies={{ 'd3-force': 'latest', 'd3-quadtree': 'latest' }}
+/>
+
+We've changed our `getLayoutedElements` to a hook called `useLayoutedElements`
+instead. Additonally, instead of passing in the nodes and edges explicitly, we'll
+use get `getNodes` and `getEdges` functions from the `useReactFlow` hook. This
+is important when combined with the store selector in `initialised` because it
+will prevent us from reconfiguring the simulation any time the nodes update.
+
+The simulation is configured with a number of different forces applied so you
+can see how they interact: play around in your own code to see how you want to
+configure those forces. You can find the documentation and some different examples
+of d3-force [here](https://d3js.org/d3-force).
+
+:::info Rectangular collisions
+D3-Force has a built-in collision force, but it assumes nodes are circles. We've
+thrown together a custom force in `collision.js` that uses a similar algorithm
+but accounts for our rectangular nodes instead. Feel free to steal it or let us
+know if you have any suggestions for improvements!
+:::
+
+The tick function progresses the simulation by one step and then updates React
+Flow with the new node positions. We've also included a demonstration on how to
+handle node dragging while the simulation is running: if your flow isn't interactive
+you can ignore that part!
+
+:::info
+For larger graphs, computing the force layout every render forever is going to
+incur a big performance hit. In this example we have a simple toggle to turn the
+layouting on and off, but you might want to come up with some other approach to
+only compute the layout when necessary.
+:::
+
+<!-- ### Cola.js
+
+Cola descibes itself as a "constraint-based layout engine" and functions similar
+to d3-force: the constraints
+
+<CodeViewer
+  codePath="api-flows/LayoutingFlow5-Cola"
+  editorOptions={editorOptions}
+  applyStyles={false}
+  additionalFiles={['nodes-edges.js']}
+  dependencies={{ webcola: 'latest' }}
+/> -->
+
+### Elkjs
+
+Elkjs is certainly the most configurable option available, but it's also the most
+complicated. Elkjs is a Java library that's been ported to JavaScript, and it
+provides a huge number of options for configuring the layout of your graph.
+
+<CodeViewer
+  codePath="api-flows/LayoutingFlow6-Elkjs"
+  editorOptions={editorOptions}
+  applyStyles={false}
+  additionalFiles={['nodes-edges.js']}
+  dependencies={{ elkjs: 'latest' }}
+/>
+
+At it's most basic we can compute layouts similar to dagre, but because the layouting
+algorithm runs asynchronously we need to create a `useLayoutedElements` hook similar
+to the one we created for d3-force.
+
+:::info The ELK reference is your new best friend
+We don't often recommend elkjs because it's complexity makes it difficult for us to
+support folks when they need it. If you do decide to use it, you'll want to keep
+the original [Java API reference](https://eclipse.dev/elk/reference.html) handy.
+:::
+
+We've also included a few examples of some of the other layouting algorithms
+available, including a non-interactive force layout.
+
+### Honourable Mentions
+
+Of course, we can't go through every layouting library out there: we'd never work
+on anything else! Here are some other libraries we've come across that might be
+worth taking a look at:
+
+- If you want to use dagre or d3-hierarchy but need to support nodes with different
+  dimensions, both [d3-flextree](https://github.com/klortho/d3-flextree) and
+  [entitree-flex](https://github.com/codeledge/entitree-flex) look promising.
+- [Cola.js](https://github.com/tgdwyer/WebCola) looks like a promising option for
+  so-called "constraint-based" layouts. We haven't had time to properly investigate
+  it yet, but it looks like you can achieve results similar to d3-force but with
+  a lot more control.
+
+## Routing Edges
+
+If you don't have any requirements for edge routing, you can use one of the
+layouting libraries above to position nodes and let the edges fall wherever they
+may. Otherwise, you'll want to look into some libraries and techniques for edge
+routing.
+
+Your options here are more limited than for node layouting, but here are some
+resources we thought looked promising:
+
+- [react-flow-smart-edge](https://github.com/tisoap/react-flow-smart-edge)
+- [Routing Orthogonal Diagram Connectors in JavaScript](https://medium.com/swlh/routing-orthogonal-diagram-connectors-in-javascript-191dc2c5ff70)
+- [elkjs](https://github.com/kieler/elkjs) (again!) has some algorithms just for
+  edge routing, such as [libavoid](https://eclipse.dev/elk/reference/algorithms/org-eclipse-elk-alg-libavoid.html).
+
+If you do explore some custom edge routing options, consider contributing back to
+the community by writing a blog post or creating a library!

--- a/docs/guides/layouting.mdx
+++ b/docs/guides/layouting.mdx
@@ -26,6 +26,10 @@ testing out the different layouting options.
   additionalFiles={['nodes-edges.js']}
 />
 
+Each of the examples that follow will be built on this empty flow. Where possible
+we've tried to keep the examples confined to just one `index.js` file so it's easy
+for you to compare how they're set up.
+
 ## Layouting Nodes
 
 For layouting nodes, there are a few third-party libraries that we think are worth

--- a/docs/guides/layouting.mdx
+++ b/docs/guides/layouting.mdx
@@ -28,36 +28,13 @@ testing out the different layouting options.
 
 ## Layouting Nodes
 
-For layouting nodes we have a few options, you may want to consider:
+For layouting nodes, there are a few third-party libraries that we think are worth
+checking out:
 
-<div className="next-steps" style={{ margin: '0 0 var(--ifm-paragraph-margin-bottom)' }}>
-  <a className="next-steps__item" href="https://github.com/dagrejs/dagre">
-    <span className="next-steps__item-sublabel">Directed graph layout for JavaScript</span>
-    <span>
-      dagre <sup>⬈</sup>
-    </span>
-  </a>
-  <a className="next-steps__item" href="https://github.com/d3/d3-hierarchy">
-    <span className="next-steps__item-sublabel">
-      2D layout algorithms for visualizing hierarchical data.
-    </span>
-    <span>
-      d3-hierarchy <sup>⬈</sup>
-    </span>
-  </a>
-  <a className="next-steps__item" href="https://github.com/kieler/elkjs">
-    <span className="next-steps__item-sublabel">ELK's layout algorithms for JavaScript</span>
-    <span>
-      elkjs <sup>⬈</sup>
-    </span>
-  </a>
-  <a className="next-steps__item" href="#honourable-mentions">
-    <span className="next-steps__item-sublabel">
-      Alternatives we haven't had time to explore yet
-    </span>
-    <span>Honourable mentions</span>
-  </a>
-</div>
+- Dagre
+- D3-Hierarchy
+- D3-Force
+- ELK
 
 We've loosely ordered these options from simplest to most complex, where dagre
 is largely a drop-in solution and elkjs is a full-blown highly configurable
@@ -69,6 +46,9 @@ you can refer back to [here](https://reactflow.dev/docs/examples/layout/dagre/)
 and [here](https://reactflow.dev/docs/examples/layout/elkjs/).
 
 ### Dagre
+
+- Repo: https://github.com/dagrejs/dagre
+- Docs: https://github.com/dagrejs/dagre/wiki#configuring-the-layout
 
 Dagre is a simple library for layouting directed graphs. It has minimal configuration
 options and a focus on speed over choosing the most optimal layout. If you need
@@ -109,6 +89,9 @@ see.
 
 ### D3-Hierarchy
 
+- Repo: https://github.com/d3/d3-hierarchy
+- Docs: https://d3js.org/d3-hierarchy
+
 When you know your graph is a tree with a single root node, d3-hierarchy can
 provide a handful of interesting layouting options. While the library can layout
 a simple tree just fine, it also has layouting algorithms for tree maps, partition
@@ -130,6 +113,9 @@ choice if you're displaying lots of different node types.
 :::
 
 ### D3-Force
+
+- Repo: https://github.com/d3/d3-force
+- Docs: https://d3js.org/d3-force
 
 Force something more interesting than a tree, a force-directed layout might be
 the way to go. D3-Force is a physics-based layouting library that can be used
@@ -193,6 +179,9 @@ to d3-force: the constraints
 /> -->
 
 ### Elkjs
+
+- Repo: https://github.com/kieler/elkjs
+- Docs: https://eclipse.dev/elk/reference.html (good luck!)
 
 Elkjs is certainly the most configurable option available, but it's also the most
 complicated. Elkjs is a Java library that's been ported to JavaScript, and it

--- a/docs/guides/layouting.mdx
+++ b/docs/guides/layouting.mdx
@@ -4,7 +4,7 @@ sidebar_position: 5
 ---
 
 import CodeViewer from '/src/components/CodeViewer';
-const editorOptions = { editorHeight: 500 };
+const editorOptions = { editorHeight: '50vh' };
 
 We regularly get asked how to handle layouting in React Flow. While we could build
 some basic layouting into React Flow, we believe that **you know your app's
@@ -21,8 +21,8 @@ testing out the different layouting options.
 
 <CodeViewer
   codePath="api-flows/LayoutingFlow1-Empty"
-  editorOptions={editorOptions}
-  applyStyles={false}
+  options={editorOptions}
+  applyStyles={true}
   additionalFiles={['nodes-edges.js']}
 />
 
@@ -60,7 +60,7 @@ to organise your flows into a tree, _we highly recommend dagre_.
 
 <CodeViewer
   codePath="api-flows/LayoutingFlow2-Dagre"
-  editorOptions={editorOptions}
+  options={editorOptions}
   applyStyles={false}
   additionalFiles={['nodes-edges.js']}
   dependencies={{ '@dagrejs/dagre': 'latest' }}
@@ -103,7 +103,7 @@ layouts, and enclosure diagrams.
 
 <CodeViewer
   codePath="api-flows/LayoutingFlow3-D3-Hierarchy"
-  editorOptions={editorOptions}
+  options={editorOptions}
   applyStyles={false}
   additionalFiles={['nodes-edges.js']}
   dependencies={{ 'd3-hierarchy': 'latest' }}
@@ -133,7 +133,7 @@ First, let's see what it does:
 
 <CodeViewer
   codePath="api-flows/LayoutingFlow4-D3-Force"
-  editorOptions={editorOptions}
+  options={editorOptions}
   applyStyles={false}
   additionalFiles={['nodes-edges.js', 'collide.js']}
   dependencies={{ 'd3-force': 'latest', 'd3-quadtree': 'latest' }}
@@ -176,7 +176,7 @@ to d3-force: the constraints
 
 <CodeViewer
   codePath="api-flows/LayoutingFlow5-Cola"
-  editorOptions={editorOptions}
+  options={editorOptions}
   applyStyles={false}
   additionalFiles={['nodes-edges.js']}
   dependencies={{ webcola: 'latest' }}
@@ -193,7 +193,7 @@ provides a huge number of options for configuring the layout of your graph.
 
 <CodeViewer
   codePath="api-flows/LayoutingFlow6-Elkjs"
-  editorOptions={editorOptions}
+  options={editorOptions}
   applyStyles={false}
   additionalFiles={['nodes-edges.js']}
   dependencies={{ elkjs: 'latest' }}

--- a/src/components/CodeViewer/api-flows/LayoutingFlow1-Empty/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow1-Empty/index.js
@@ -36,9 +36,6 @@ const LayoutFlow = () => {
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
       fitView
-      zoomOnScroll={false}
-      zoomOnPinch={false}
-      zoomOnDoubleClick={false}
     />
   );
 };

--- a/src/components/CodeViewer/api-flows/LayoutingFlow1-Empty/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow1-Empty/index.js
@@ -1,0 +1,52 @@
+import React, { useCallback } from 'react';
+import ReactFlow, {
+  ReactFlowProvider,
+  useNodesState,
+  useEdgesState,
+  useReactFlow,
+} from 'reactflow';
+
+import { initialNodes, initialEdges } from './nodes-edges.js';
+import 'reactflow/dist/style.css';
+
+const getLayoutedElements = (nodes, edges) => {
+  return { nodes, edges };
+};
+
+const LayoutFlow = () => {
+  const { fitView } = useReactFlow();
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+  const onLayout = useCallback(() => {
+    const layouted = getLayoutedElements(nodes, edges);
+
+    setNodes([...layouted.nodes]);
+    setEdges([...layouted.edges]);
+
+    window.requestAnimationFrame(() => {
+      fitView();
+    });
+  }, [nodes, edges]);
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      fitView
+      zoomOnScroll={false}
+      zoomOnPinch={false}
+      zoomOnDoubleClick={false}
+    />
+  );
+};
+
+export default function () {
+  return (
+    <ReactFlowProvider>
+      <LayoutFlow />
+    </ReactFlowProvider>
+  );
+}

--- a/src/components/CodeViewer/api-flows/LayoutingFlow1-Empty/nodes-edges.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow1-Empty/nodes-edges.js
@@ -1,0 +1,47 @@
+export const initialNodes = [
+  {
+    id: '1',
+    type: 'input',
+    data: { label: 'input' },
+    position: { x: 0, y: 0 },
+  },
+  {
+    id: '2',
+    data: { label: 'node 2' },
+    position: { x: 0, y: 100 },
+  },
+  {
+    id: '2a',
+    data: { label: 'node 2a' },
+    position: { x: 0, y: 200 },
+  },
+  {
+    id: '2b',
+    data: { label: 'node 2b' },
+    position: { x: 0, y: 300 },
+  },
+  {
+    id: '2c',
+    data: { label: 'node 2c' },
+    position: { x: 0, y: 400 },
+  },
+  {
+    id: '2d',
+    data: { label: 'node 2d' },
+    position: { x: 0, y: 500 },
+  },
+  {
+    id: '3',
+    data: { label: 'node 3' },
+    position: { x: 200, y: 100 },
+  },
+];
+
+export const initialEdges = [
+  { id: 'e12', source: '1', target: '2', animated: true },
+  { id: 'e13', source: '1', target: '3', animated: true },
+  { id: 'e22a', source: '2', target: '2a', animated: true },
+  { id: 'e22b', source: '2', target: '2b', animated: true },
+  { id: 'e22c', source: '2', target: '2c', animated: true },
+  { id: 'e2c2d', source: '2c', target: '2d', animated: true },
+];

--- a/src/components/CodeViewer/api-flows/LayoutingFlow2-Dagre/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow2-Dagre/index.js
@@ -13,14 +13,11 @@ import 'reactflow/dist/style.css';
 
 const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
 
-const getNodeDimensions = ({ id }) =>
-  document.querySelector(`[data-id="${id}"]`).getBoundingClientRect();
-
 const getLayoutedElements = (nodes, edges, options) => {
   g.setGraph({ rankdir: options.direction });
 
   edges.forEach((edge) => g.setEdge(edge.source, edge.target));
-  nodes.forEach((node) => g.setNode(node.id, getNodeDimensions(node)));
+  nodes.forEach((node) => g.setNode(node.id, node));
 
   Dagre.layout(g);
 

--- a/src/components/CodeViewer/api-flows/LayoutingFlow2-Dagre/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow2-Dagre/index.js
@@ -56,9 +56,6 @@ const LayoutFlow = () => {
       edges={edges}
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
-      zoomOnScroll={false}
-      zoomOnPinch={false}
-      zoomOnDoubleClick={false}
       fitView
     >
       <Panel position="top-right">

--- a/src/components/CodeViewer/api-flows/LayoutingFlow2-Dagre/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow2-Dagre/index.js
@@ -1,0 +1,81 @@
+import Dagre from '@dagrejs/dagre';
+import React, { useCallback } from 'react';
+import ReactFlow, {
+  ReactFlowProvider,
+  Panel,
+  useNodesState,
+  useEdgesState,
+  useReactFlow,
+} from 'reactflow';
+
+import { initialNodes, initialEdges } from './nodes-edges.js';
+import 'reactflow/dist/style.css';
+
+const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
+
+const getNodeDimensions = ({ id }) =>
+  document.querySelector(`[data-id="${id}"]`).getBoundingClientRect();
+
+const getLayoutedElements = (nodes, edges, options) => {
+  g.setGraph({ rankdir: options.direction });
+
+  edges.forEach((edge) => g.setEdge(edge.source, edge.target));
+  nodes.forEach((node) => g.setNode(node.id, getNodeDimensions(node)));
+
+  Dagre.layout(g);
+
+  return {
+    nodes: nodes.map((node) => {
+      const { x, y } = g.node(node.id);
+
+      return { ...node, position: { x, y } };
+    }),
+    edges,
+  };
+};
+
+const LayoutFlow = () => {
+  const { fitView } = useReactFlow();
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+  const onLayout = useCallback(
+    (direction) => {
+      const layouted = getLayoutedElements(nodes, edges, { direction });
+
+      setNodes([...layouted.nodes]);
+      setEdges([...layouted.edges]);
+
+      window.requestAnimationFrame(() => {
+        fitView();
+      });
+    },
+    [nodes, edges]
+  );
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      zoomOnScroll={false}
+      zoomOnPinch={false}
+      zoomOnDoubleClick={false}
+      fitView
+    >
+      <Panel position="top-right">
+        <button onClick={() => onLayout('TB')}>vertical layout</button>
+        <button onClick={() => onLayout('LR')}>horizontal layout</button>
+      </Panel>
+    </ReactFlow>
+  );
+};
+
+export default function () {
+  return (
+    <ReactFlowProvider>
+      <LayoutFlow />
+    </ReactFlowProvider>
+  );
+}

--- a/src/components/CodeViewer/api-flows/LayoutingFlow2-Dagre/nodes-edges.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow2-Dagre/nodes-edges.js
@@ -1,0 +1,47 @@
+export const initialNodes = [
+  {
+    id: '1',
+    type: 'input',
+    data: { label: 'input' },
+    position: { x: 0, y: 0 },
+  },
+  {
+    id: '2',
+    data: { label: 'node 2' },
+    position: { x: 0, y: 100 },
+  },
+  {
+    id: '2a',
+    data: { label: 'node 2a' },
+    position: { x: 0, y: 200 },
+  },
+  {
+    id: '2b',
+    data: { label: 'node 2b' },
+    position: { x: 0, y: 300 },
+  },
+  {
+    id: '2c',
+    data: { label: 'node 2c' },
+    position: { x: 0, y: 400 },
+  },
+  {
+    id: '2d',
+    data: { label: 'node 2d' },
+    position: { x: 0, y: 500 },
+  },
+  {
+    id: '3',
+    data: { label: 'node 3' },
+    position: { x: 200, y: 100 },
+  },
+];
+
+export const initialEdges = [
+  { id: 'e12', source: '1', target: '2', animated: true },
+  { id: 'e13', source: '1', target: '3', animated: true },
+  { id: 'e22a', source: '2', target: '2a', animated: true },
+  { id: 'e22b', source: '2', target: '2b', animated: true },
+  { id: 'e22c', source: '2', target: '2c', animated: true },
+  { id: 'e2c2d', source: '2c', target: '2d', animated: true },
+];

--- a/src/components/CodeViewer/api-flows/LayoutingFlow3-D3-Hierarchy/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow3-D3-Hierarchy/index.js
@@ -1,0 +1,81 @@
+import { stratify, tree } from 'd3-hierarchy';
+import React, { useCallback, useMemo } from 'react';
+import ReactFlow, {
+  ReactFlowProvider,
+  Panel,
+  useNodesState,
+  useEdgesState,
+  useReactFlow,
+} from 'reactflow';
+
+import { initialNodes, initialEdges } from './nodes-edges.js';
+import 'reactflow/dist/style.css';
+
+const g = tree();
+
+const getLayoutedElements = (nodes, edges, options) => {
+  if (nodes.length === 0) return { nodes, edges };
+
+  const { width, height } = document
+    .querySelector(`[data-id="${nodes[0].id}"]`)
+    .getBoundingClientRect();
+  const hierarchy = stratify()
+    .id((node) => node.id)
+    .parentId((node) => edges.find((edge) => edge.target === node.id)?.source);
+  const root = hierarchy(nodes);
+  const layout = g.nodeSize([width * 2, height * 2])(root);
+
+  return {
+    nodes: layout
+      .descendants()
+      .map((node) => ({ ...node.data, position: { x: node.x, y: node.y } })),
+    edges,
+  };
+};
+
+const LayoutFlow = () => {
+  const { fitView } = useReactFlow();
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+  const onLayout = useCallback(
+    (direction) => {
+      const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(nodes, edges, {
+        direction,
+      });
+
+      setNodes([...layoutedNodes]);
+      setEdges([...layoutedEdges]);
+
+      window.requestAnimationFrame(() => {
+        fitView();
+      });
+    },
+    [nodes, edges]
+  );
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      zoomOnScroll={false}
+      zoomOnPinch={false}
+      zoomOnDoubleClick={false}
+      fitView
+    >
+      <Panel position="top-right">
+        <button onClick={onLayout}>layout</button>
+      </Panel>
+    </ReactFlow>
+  );
+};
+
+export default function () {
+  return (
+    <ReactFlowProvider>
+      <LayoutFlow />
+    </ReactFlowProvider>
+  );
+}

--- a/src/components/CodeViewer/api-flows/LayoutingFlow3-D3-Hierarchy/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow3-D3-Hierarchy/index.js
@@ -60,9 +60,6 @@ const LayoutFlow = () => {
       edges={edges}
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
-      zoomOnScroll={false}
-      zoomOnPinch={false}
-      zoomOnDoubleClick={false}
       fitView
     >
       <Panel position="top-right">

--- a/src/components/CodeViewer/api-flows/LayoutingFlow3-D3-Hierarchy/nodes-edges.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow3-D3-Hierarchy/nodes-edges.js
@@ -1,0 +1,47 @@
+export const initialNodes = [
+  {
+    id: '1',
+    type: 'input',
+    data: { label: 'input' },
+    position: { x: 0, y: 0 },
+  },
+  {
+    id: '2',
+    data: { label: 'node 2' },
+    position: { x: 0, y: 100 },
+  },
+  {
+    id: '2a',
+    data: { label: 'node 2a' },
+    position: { x: 0, y: 200 },
+  },
+  {
+    id: '2b',
+    data: { label: 'node 2b' },
+    position: { x: 0, y: 300 },
+  },
+  {
+    id: '2c',
+    data: { label: 'node 2c' },
+    position: { x: 0, y: 400 },
+  },
+  {
+    id: '2d',
+    data: { label: 'node 2d' },
+    position: { x: 0, y: 500 },
+  },
+  {
+    id: '3',
+    data: { label: 'node 3' },
+    position: { x: 200, y: 100 },
+  },
+];
+
+export const initialEdges = [
+  { id: 'e12', source: '1', target: '2', animated: true },
+  { id: 'e13', source: '1', target: '3', animated: true },
+  { id: 'e22a', source: '2', target: '2a', animated: true },
+  { id: 'e22b', source: '2', target: '2b', animated: true },
+  { id: 'e22c', source: '2', target: '2c', animated: true },
+  { id: 'e2c2d', source: '2c', target: '2d', animated: true },
+];

--- a/src/components/CodeViewer/api-flows/LayoutingFlow4-D3-Force/collide.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow4-D3-Force/collide.js
@@ -1,0 +1,49 @@
+import { quadtree } from 'd3-quadtree';
+
+export function collide() {
+  let nodes = [];
+  let force = (alpha) => {
+    const tree = quadtree(
+      nodes,
+      (d) => d.x,
+      (d) => d.y
+    );
+
+    for (const node of nodes) {
+      const r = node.width / 2;
+      const nx1 = node.x - r;
+      const nx2 = node.x + r;
+      const ny1 = node.y - r;
+      const ny2 = node.y + r;
+
+      tree.visit((quad, x1, y1, x2, y2) => {
+        if (!quad.length) {
+          do {
+            if (quad.data !== node) {
+              const r = node.width / 2 + quad.data.width / 2;
+              let x = node.x - quad.data.x;
+              let y = node.y - quad.data.y;
+              let l = Math.hypot(x, y);
+
+              if (l < r) {
+                l = ((l - r) / l) * alpha;
+                node.x -= x *= l;
+                node.y -= y *= l;
+                quad.data.x += x;
+                quad.data.y += y;
+              }
+            }
+          } while ((quad = quad.next));
+        }
+
+        return x1 > nx2 || x2 < nx1 || y1 > ny2 || y2 < ny1;
+      });
+    }
+  };
+
+  force.initialize = (newNodes) => (nodes = newNodes);
+
+  return force;
+}
+
+export default collide;

--- a/src/components/CodeViewer/api-flows/LayoutingFlow4-D3-Force/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow4-D3-Force/index.js
@@ -93,9 +93,6 @@ const LayoutFlow = () => {
       edges={edges}
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
-      zoomOnScroll={false}
-      zoomOnPinch={false}
-      zoomOnDoubleClick={false}
     >
       <Panel>
         {initialised && (

--- a/src/components/CodeViewer/api-flows/LayoutingFlow4-D3-Force/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow4-D3-Force/index.js
@@ -1,0 +1,115 @@
+import { forceSimulation, forceLink, forceManyBody, forceX, forceY } from 'd3-force';
+import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import ReactFlow, {
+  ReactFlowProvider,
+  Panel,
+  useNodesState,
+  useEdgesState,
+  useReactFlow,
+  useStore,
+} from 'reactflow';
+
+import { initialNodes, initialEdges } from './nodes-edges.js';
+import { collide } from './collide.js';
+
+import 'reactflow/dist/style.css';
+
+const simulation = forceSimulation()
+  .force('charge', forceManyBody().strength(-1000))
+  .force('x', forceX().x(0).strength(0.05))
+  .force('y', forceY().y(0).strength(0.05))
+  .force('collide', collide())
+  .alphaTarget(0.05)
+  .stop();
+
+const useLayoutedElements = () => {
+  const { getNodes, setNodes, getEdges, fitView } = useReactFlow();
+  const initialised = useStore((store) =>
+    [...store.nodeInternals.values()].every((node) => node.width && node.height)
+  );
+
+  return useMemo(() => {
+    let nodes = getNodes().map((node) => ({ ...node, x: node.position.x, y: node.position.y }));
+    let edges = getEdges().map((edge) => edge);
+    let running = false;
+
+    // If React Flow hasn't initialised our nodes with a width and height yet, or
+    // if there are no nodes in the flow, then we can't run the simulation!
+    if (!initialised || nodes.length === 0) return [false, {}];
+
+    simulation.nodes(nodes).force(
+      'link',
+      forceLink(edges)
+        .id((d) => d.id)
+        .strength(0.05)
+        .distance(100)
+    );
+
+    // The tick function is called every animation frame while the simulation is
+    // running and progresses the simulation one step forward each time.
+    const tick = () => {
+      getNodes().forEach((node, i) => {
+        const dragging = Boolean(document.querySelector(`[data-id="${node.id}"].dragging`));
+
+        // Setting the fx/fy properties of a node tells the simulation to "fix"
+        // the node at that position and ignore any forces that would normally
+        // cause it to move.
+        nodes[i].fx = dragging ? node.position.x : null;
+        nodes[i].fy = dragging ? node.position.y : null;
+      });
+
+      simulation.tick();
+      setNodes(nodes.map((node) => ({ ...node, position: { x: node.x, y: node.y } })));
+
+      window.requestAnimationFrame(() => {
+        // Give React and React Flow a chance to update and render the new node
+        // positions before we fit the viewport to the new layout.
+        fitView();
+
+        // If the simulation hasn't be stopped, schedule another tick.
+        if (running) tick();
+      });
+    };
+
+    const toggle = () => {
+      running = !running;
+      running && window.requestAnimationFrame(tick);
+    };
+
+    const isRunning = () => running;
+
+    return [true, { toggle, isRunning }];
+  }, [initialised]);
+};
+
+const LayoutFlow = () => {
+  const [nodes, , onNodesChange] = useNodesState(initialNodes);
+  const [edges, , onEdgesChange] = useEdgesState(initialEdges);
+  const [initialised, { toggle, isRunning }] = useLayoutedElements();
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      zoomOnScroll={false}
+      zoomOnPinch={false}
+      zoomOnDoubleClick={false}
+    >
+      <Panel>
+        {initialised && (
+          <button onClick={toggle}>{isRunning() ? 'Stop' : 'Start'} force simulation</button>
+        )}
+      </Panel>
+    </ReactFlow>
+  );
+};
+
+export default function () {
+  return (
+    <ReactFlowProvider>
+      <LayoutFlow />
+    </ReactFlowProvider>
+  );
+}

--- a/src/components/CodeViewer/api-flows/LayoutingFlow4-D3-Force/nodes-edges.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow4-D3-Force/nodes-edges.js
@@ -1,0 +1,47 @@
+export const initialNodes = [
+  {
+    id: '1',
+    type: 'input',
+    data: { label: 'input' },
+    position: { x: 0, y: 0 },
+  },
+  {
+    id: '2',
+    data: { label: 'node 2' },
+    position: { x: 0, y: 100 },
+  },
+  {
+    id: '2a',
+    data: { label: 'node 2a' },
+    position: { x: 0, y: 200 },
+  },
+  {
+    id: '2b',
+    data: { label: 'node 2b' },
+    position: { x: 0, y: 300 },
+  },
+  {
+    id: '2c',
+    data: { label: 'node 2c' },
+    position: { x: 0, y: 400 },
+  },
+  {
+    id: '2d',
+    data: { label: 'node 2d' },
+    position: { x: 0, y: 500 },
+  },
+  {
+    id: '3',
+    data: { label: 'node 3' },
+    position: { x: 200, y: 100 },
+  },
+];
+
+export const initialEdges = [
+  { id: 'e12', source: '1', target: '2', animated: true },
+  { id: 'e13', source: '1', target: '3', animated: true },
+  { id: 'e22a', source: '2', target: '2a', animated: true },
+  { id: 'e22b', source: '2', target: '2b', animated: true },
+  { id: 'e22c', source: '2', target: '2c', animated: true },
+  { id: 'e2c2d', source: '2c', target: '2d', animated: true },
+];

--- a/src/components/CodeViewer/api-flows/LayoutingFlow5-Cola/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow5-Cola/index.js
@@ -104,9 +104,6 @@ const LayoutFlow = () => {
       edges={edges}
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
-      zoomOnScroll={false}
-      zoomOnPinch={false}
-      zoomOnDoubleClick={false}
     >
       <Panel>
         {initialised && (

--- a/src/components/CodeViewer/api-flows/LayoutingFlow5-Cola/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow5-Cola/index.js
@@ -1,0 +1,126 @@
+import * as Cola from 'webcola';
+import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import ReactFlow, {
+  ReactFlowProvider,
+  Panel,
+  useNodesState,
+  useEdgesState,
+  useReactFlow,
+  useStore,
+} from 'reactflow';
+
+import { initialNodes, initialEdges } from './nodes-edges.js';
+
+import 'reactflow/dist/style.css';
+
+const useLayoutedElements = () => {
+  const { getNodes, setNodes, getEdges, fitView } = useReactFlow();
+  const initialised = useStore((store) =>
+    [...store.nodeInternals.values()].every((node) => node.width && node.height)
+  );
+
+  return useMemo(() => {
+    // If React Flow hasn't initialised our nodes with a width and height yet, or
+    // if there are no nodes in the flow, then we can't run the simulation!
+    if (!initialised || getNodes().length === 0) return [false, {}];
+
+    let running = false;
+    let idMap = new Map();
+    let nodes = getNodes().map((node, idx) => {
+      idMap.set(node.id, idx);
+
+      return { ...node, index: idx, x: node.position.x, y: node.position.y };
+    });
+    let links = getEdges().map((edge) => {
+      const source = idMap.get(edge.source);
+      const target = idMap.get(edge.target);
+
+      return { source, target };
+    });
+
+    const simulation = new Cola.Layout()
+      .nodes(nodes)
+      .links(links)
+      .symmetricDiffLinkLengths(100)
+      // These initial parameters tell Cola how many iterations to run immediately
+      // on startup. The bit we care about is that `false` that tells Cold not to
+      // run the simulation loop automatically: we want to `tick` it manually!
+      .start(1, 1, 1, 1, false, true);
+
+    const tick = () => {
+      getNodes().forEach((node, i) => {
+        const dragging = Boolean(document.querySelector(`[data-id="${node.id}"].dragging`));
+
+        if (dragging && !nodes[i].fixed) {
+          Cola.Layout.dragStart(nodes[i]);
+        } else if (dragging) {
+          Cola.Layout.drag(nodes[i], {
+            x: node.position.x,
+            y: node.position.y,
+          });
+
+          !simulation.alpha() && simulation.resume();
+        } else if (nodes[i].fixed) {
+          Cola.Layout.dragEnd(nodes[i]);
+        }
+      });
+
+      simulation.tick();
+      setNodes(nodes.map((node) => ({ ...node, position: { x: node.x, y: node.y } })));
+
+      window.requestAnimationFrame(() => {
+        // Give React and React Flow a chance to update and render the new node
+        // positions before we fit the viewport to the new layout.
+        fitView();
+
+        // If the simulation hasn't be stopped, schedule another tick.
+        if (running) tick();
+      });
+    };
+
+    const toggle = () => {
+      running = !running;
+
+      if (running) {
+        !simulation.alpha() && simulation.resume();
+        window.requestAnimationFrame(tick);
+      }
+    };
+
+    const isRunning = () => running;
+
+    return [true, { toggle, isRunning }];
+  }, [initialised]);
+};
+
+const LayoutFlow = () => {
+  const [nodes, , onNodesChange] = useNodesState(initialNodes);
+  const [edges, , onEdgesChange] = useEdgesState(initialEdges);
+  const [initialised, { toggle, isRunning }] = useLayoutedElements();
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      zoomOnScroll={false}
+      zoomOnPinch={false}
+      zoomOnDoubleClick={false}
+    >
+      <Panel>
+        {initialised && (
+          <button onClick={toggle}>{isRunning() ? 'Stop' : 'Start'} force simulation</button>
+        )}
+      </Panel>
+    </ReactFlow>
+  );
+};
+
+export default function () {
+  return (
+    <ReactFlowProvider>
+      <LayoutFlow />
+    </ReactFlowProvider>
+  );
+}

--- a/src/components/CodeViewer/api-flows/LayoutingFlow5-Cola/nodes-edges.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow5-Cola/nodes-edges.js
@@ -1,0 +1,47 @@
+export const initialNodes = [
+  {
+    id: '1',
+    type: 'input',
+    data: { label: 'input' },
+    position: { x: 0, y: 0 },
+  },
+  {
+    id: '2',
+    data: { label: 'node 2' },
+    position: { x: 0, y: 100 },
+  },
+  {
+    id: '2a',
+    data: { label: 'node 2a' },
+    position: { x: 0, y: 200 },
+  },
+  {
+    id: '2b',
+    data: { label: 'node 2b' },
+    position: { x: 0, y: 300 },
+  },
+  {
+    id: '2c',
+    data: { label: 'node 2c' },
+    position: { x: 0, y: 400 },
+  },
+  {
+    id: '2d',
+    data: { label: 'node 2d' },
+    position: { x: 0, y: 500 },
+  },
+  {
+    id: '3',
+    data: { label: 'node 3' },
+    position: { x: 200, y: 100 },
+  },
+];
+
+export const initialEdges = [
+  { id: 'e12', source: '1', target: '2', animated: true },
+  { id: 'e13', source: '1', target: '3', animated: true },
+  { id: 'e22a', source: '2', target: '2a', animated: true },
+  { id: 'e22b', source: '2', target: '2b', animated: true },
+  { id: 'e22c', source: '2', target: '2c', animated: true },
+  { id: 'e2c2d', source: '2c', target: '2d', animated: true },
+];

--- a/src/components/CodeViewer/api-flows/LayoutingFlow6-Elkjs/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow6-Elkjs/index.js
@@ -1,0 +1,110 @@
+import ELK from 'elkjs/lib/elk.bundled.js';
+import React, { useCallback } from 'react';
+import ReactFlow, {
+  ReactFlowProvider,
+  Panel,
+  useNodesState,
+  useEdgesState,
+  useReactFlow,
+} from 'reactflow';
+
+import { initialNodes, initialEdges } from './nodes-edges.js';
+import 'reactflow/dist/style.css';
+
+const elk = new ELK();
+
+const useLayoutedElements = () => {
+  const { getNodes, setNodes, getEdges, fitView } = useReactFlow();
+  const defaultOptions = {
+    'elk.algorithm': 'layered',
+    'elk.layered.spacing.nodeNodeBetweenLayers': 100,
+    'elk.spacing.nodeNode': 80,
+  };
+
+  const getLayoutedElements = useCallback((options) => {
+    const layoutOptions = { ...defaultOptions, ...options };
+    const graph = {
+      id: 'root',
+      layoutOptions: layoutOptions,
+      children: getNodes(),
+      edges: getEdges(),
+    };
+
+    elk.layout(graph).then(({ children }) => {
+      // By mutating the children in-place we saves ourselves from creating a
+      // needless copy of the nodes array.
+      children.forEach((node) => {
+        node.position = { x: node.x, y: node.y };
+      });
+
+      setNodes(children);
+      window.requestAnimationFrame(() => {
+        fitView();
+      });
+    });
+  }, []);
+
+  return { getLayoutedElements };
+};
+
+const LayoutFlow = () => {
+  const [nodes, , onNodesChange] = useNodesState(initialNodes);
+  const [edges, , onEdgesChange] = useEdgesState(initialEdges);
+  const { getLayoutedElements } = useLayoutedElements();
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      fitView
+      zoomOnScroll={false}
+      zoomOnPinch={false}
+      zoomOnDoubleClick={false}
+    >
+      <Panel position="top-right">
+        <button
+          onClick={() =>
+            getLayoutedElements({ 'elk.algorithm': 'layered', 'elk.direction': 'DOWN' })
+          }
+        >
+          vertical layout
+        </button>
+        <button
+          onClick={() =>
+            getLayoutedElements({ 'elk.algorithm': 'layered', 'elk.direction': 'RIGHT' })
+          }
+        >
+          horizontal layout
+        </button>
+        <button
+          onClick={() =>
+            getLayoutedElements({
+              'elk.algorithm': 'org.eclipse.elk.radial',
+            })
+          }
+        >
+          radial layout
+        </button>
+        <button
+          onClick={() =>
+            getLayoutedElements({
+              'elk.algorithm': 'org.eclipse.elk.force',
+            })
+          }
+        >
+          force layout
+        </button>
+      </Panel>
+    </ReactFlow>
+  );
+};
+
+export default function () {
+  return (
+    <ReactFlowProvider>
+      <LayoutFlow />
+    </ReactFlowProvider>
+  );
+}

--- a/src/components/CodeViewer/api-flows/LayoutingFlow6-Elkjs/index.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow6-Elkjs/index.js
@@ -59,9 +59,6 @@ const LayoutFlow = () => {
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
       fitView
-      zoomOnScroll={false}
-      zoomOnPinch={false}
-      zoomOnDoubleClick={false}
     >
       <Panel position="top-right">
         <button

--- a/src/components/CodeViewer/api-flows/LayoutingFlow6-Elkjs/nodes-edges.js
+++ b/src/components/CodeViewer/api-flows/LayoutingFlow6-Elkjs/nodes-edges.js
@@ -1,0 +1,47 @@
+export const initialNodes = [
+  {
+    id: '1',
+    type: 'input',
+    data: { label: 'input' },
+    position: { x: 0, y: 0 },
+  },
+  {
+    id: '2',
+    data: { label: 'node 2' },
+    position: { x: 0, y: 100 },
+  },
+  {
+    id: '2a',
+    data: { label: 'node 2a' },
+    position: { x: 0, y: 200 },
+  },
+  {
+    id: '2b',
+    data: { label: 'node 2b' },
+    position: { x: 0, y: 300 },
+  },
+  {
+    id: '2c',
+    data: { label: 'node 2c' },
+    position: { x: 0, y: 400 },
+  },
+  {
+    id: '2d',
+    data: { label: 'node 2d' },
+    position: { x: 0, y: 500 },
+  },
+  {
+    id: '3',
+    data: { label: 'node 3' },
+    position: { x: 200, y: 100 },
+  },
+];
+
+export const initialEdges = [
+  { id: 'e12', source: '1', target: '2', animated: true },
+  { id: 'e13', source: '1', target: '3', animated: true },
+  { id: 'e22a', source: '2', target: '2a', animated: true },
+  { id: 'e22b', source: '2', target: '2b', animated: true },
+  { id: 'e22c', source: '2', target: '2c', animated: true },
+  { id: 'e2c2d', source: '2c', target: '2d', animated: true },
+];


### PR DESCRIPTION
This took a bit longer to put together than expected 😓 

- [x] Brief explainer on why we don't include layouting with RF
- [x] Quick tl;dr on the options we recommend using
- [x] Show the dagre tree example
- [x] Show an example of d3-hierarchy
- [x] Create an interactive example using d3-force
  - [ ] I have a bug on my end where this sandpack preview becomes weirdly unresponsive if I interact with it when browser console _isn't_ open (????). Can someone try and investigate/repro this?
- [ ] I have a WIP example of cola.js but I couldn't yet get it interactive like the d3-force example. I'd like to hold this one back until I get that working.. I think most people haven't heard of cola anyway.
- [x] Show an expanded elkjs example: shows off some different algorithms besides the basic tree one.
- [x] Point out some resources for edge routing.  