### PR TITLE
Update quickstart.mdx

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -89,7 +89,7 @@ pnpm create vite my-react-flow-app -- --template react
   </TabItem>
 </Tabs>
 
-React Flow is published on npm as React Flow is published on npm as [`reactflow`](https://npmjs.com/package/reactflow), so go ahead and add it next.
+React Flow is published on npm as [`reactflow`](https://npmjs.com/package/reactflow), so go ahead and add it next.
 
 <Tabs>
   <TabItem value="npm" label="npm" default>


### PR DESCRIPTION
Fixed a small mistake in the sentence. A small part of the sentence was being used twice.

Before:
`React Flow is published on npm as React Flow is published on npm as reactflow`

After:
`React Flow is published on npm as reactflow`