### PR TITLE
📝  Update troubleshooting docs to explain new 'node does not exist' error.

### DIFF
--- a/docs/guides/troubleshooting.mdx
+++ b/docs/guides/troubleshooting.mdx
@@ -411,3 +411,12 @@ This warning occurs when you are trying to specify a marker type that is not bui
 ### Handle: No node id found.
 
 This warning occurs when you try to use a `<Handle />` component outside of a custom node component.
+
+### Node with id "${id}" does not exist, it may have been removed....
+
+This warning occurs when you have a custom node that removes itself on some click event _and_ you have an `onNodeClick` handler on your `<ReactFlow>` component. A common cause is a custom node with a delete button that calls `setNodes` when clicked. By the time the event bubbles up to the node's click handler, it has already been removed from the internal store and there's not much left for React Flow to do!
+
+Thare are two ways to prevent this warning:
+
+1. Call `preventDefault` or `stopPropagation` on the click event where you remove the node. This will stop the event bubbling up and the `onNodeClick` handler _will not be called_.
+2. Wrap the call to `setNodes` that removes the node in a `setTimeout` or `requestAnimationFrame` to ensure that the node is removed _after_ the `onNodeClick` handler has been called.


### PR DESCRIPTION
See https://github.com/wbkd/react-flow/pull/3294 for the relevant lib change.

This adds an explanation for the cause of the error and suggests two fixes:
- Stop event propagation on click events that also remove the node.
- Defer removing the node using a timeout.